### PR TITLE
Fix TrackNet leftover frames

### DIFF
--- a/LayerSensing/Pose/YOLOPoseMqtt.py
+++ b/LayerSensing/Pose/YOLOPoseMqtt.py
@@ -89,7 +89,7 @@ class YOLOPoseMqtt(threading.Thread):
             frame = self.image_buffer.pop(True)
             if frame.is_eos:
                 break
-            img = frame.image
+            img = frame.image.copy()
             # ensure shape matches model expectation
             if self.expected_ch == 3:
                 if img.ndim == 2:

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -78,9 +78,22 @@ class TrackNetThread:
         self.valid_size = 0
 
     def prediction(self):
-        # TrackNet prediction
-        unit = np.stack(self.images, axis=2)
-        unit = np.moveaxis(unit, -1, 0).astype('float32')/255
+        """Run TrackNet prediction on ``self.images``.
+
+        Incoming frames may have arbitrary size or color channels. Convert each
+        frame to grayscale and resize to the expected ``WIDTH``x``HEIGHT`` before
+        stacking them into a 10-channel tensor.
+        """
+        grays = []
+        for img in self.images:
+            if img.ndim == 3 and img.shape[2] == 3:
+                img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+            if img.shape[0] != HEIGHT or img.shape[1] != WIDTH:
+                img = cv2.resize(img, (WIDTH, HEIGHT))
+            grays.append(img)
+
+        unit = np.stack(grays, axis=2)
+        unit = np.moveaxis(unit, -1, 0).astype("float32") / 255
         unit = torch.from_numpy(np.asarray([unit])).to(self.device)
         with torch.no_grad():
             self.h_pred = self.model(unit)

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -68,12 +68,14 @@ class TrackNetThread:
         self.output_topic = output_topic
         # wait for new image
         self.isProcessing = False
+        self.valid_size = 0
 
     def init(self):
         self.images = []
         self.fids = []
         self.timestamps = []
         self.points:'list[Point]' = []
+        self.valid_size = 0
 
     def prediction(self):
         # TrackNet prediction
@@ -89,7 +91,10 @@ class TrackNetThread:
 
     def execute(self):
         # TrackNet
-        for idx_f, (image, fid, timestamp) in enumerate(zip(self.images, self.fids, self.timestamps)):
+        for idx_f in range(self.valid_size):
+            image = self.images[idx_f]
+            fid = self.fids[idx_f]
+            timestamp = self.timestamps[idx_f]
             # height, width, channels = image.shape
             ratio_w = self.output_width / WIDTH
             ratio_h = self.output_height / HEIGHT
@@ -131,7 +136,14 @@ class TrackNetThread:
     def run(self):
         #logging.debug("TrackNetThread started.")
         try:
-            if len(self.images) == TRACK_SIZE:
+            self.valid_size = len(self.images)
+            if self.valid_size > 0:
+                if self.valid_size < TRACK_SIZE:
+                    last_img = self.images[-1]
+                    pad = TRACK_SIZE - self.valid_size
+                    self.images.extend([last_img] * pad)
+                    self.fids.extend([self.fids[-1]] * pad)
+                    self.timestamps.extend([self.timestamps[-1]] * pad)
                 self.isProcessing = True
                 self.prediction()
                 self.execute()
@@ -247,7 +259,15 @@ class TrackNetMqtt(threading.Thread):
             list_fids.clear()
             list_timestamps.clear()
             size = 0
-        
+
+        # process remaining frames if any
+        if size > 0:
+            tracknetThread.init()
+            tracknetThread.images = list_images.copy()
+            tracknetThread.fids = list_fids.copy()
+            tracknetThread.timestamps = list_timestamps.copy()
+            tracknetThread.run()
+
         if self.csv_writer is not None:
             self.csv_writer.close()
 

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -86,6 +86,7 @@ class TrackNetThread:
         """
         grays = []
         for img in self.images:
+            img = img.copy()
             if img.ndim == 3 and img.shape[2] == 3:
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
             if img.shape[0] != HEIGHT or img.shape[1] != WIDTH:

--- a/lib/writer.py
+++ b/lib/writer.py
@@ -24,6 +24,48 @@ class CSVWriter():
         df = df.sort_values(by=["Frame"])
         df.to_csv(self.filename, mode='w+', index=False)
 
+    def close_sortByTime(self):
+        """Close CSV file and sort rows by frame number."""
+        self.csvfile.flush()
+        self.csvfile.close()
+
+        df = pd.read_csv(self.filename)
+        df = df.sort_values(by=["Frame"])
+        df.to_csv(self.filename, mode='w+', index=False)
+
+    def writePoints(self, points):
+        """Write :class:`~lib.point.Point` objects to the CSV."""
+        if isinstance(points, Point):
+            self.writer.writerow([
+                points.fid,
+                points.visibility,
+                points.x,
+                points.y,
+                points.z,
+                points.event,
+                points.timestamp,
+            ])
+        elif isinstance(points, list):
+            for p in points:
+                self.writer.writerow([
+                    p.fid,
+                    p.visibility,
+                    p.x,
+                    p.y,
+                    p.z,
+                    p.event,
+                    p.timestamp,
+                ])
+
+        self.csvfile.flush()
+
+    def setEventByTimestamp(self, event, timestamp):
+        """Update the ``Event`` column for rows matching ``timestamp``."""
+        df = pd.read_csv(self.filename)
+        df.loc[df["Timestamp"] == timestamp, "Event"] = event
+
+        df.to_csv(self.filename, mode='w+', index=False)
+
 
 class PoseCSVWriter:
     """CSV writer for pose results."""


### PR DESCRIPTION
## Summary
- handle leftover frames when TrackNet thread ends by padding frames for prediction and only writing real frames to CSV

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68769f6a46d48323987e9039cd4b88f9