### PR TITLE
Enable TrackNet overlay on pose visualizations

### DIFF
--- a/LayerSensing/Pose/YOLOPoseMqtt.py
+++ b/LayerSensing/Pose/YOLOPoseMqtt.py
@@ -4,6 +4,7 @@ import json
 import logging
 
 import cv2
+import pandas as pd
 import paho.mqtt.client as mqtt
 from ultralytics import YOLO
 from ultralytics.yolo.v8.pose.predict import PosePredictor
@@ -16,7 +17,9 @@ from lib.common import ROOTDIR
 class YOLOPoseMqtt(threading.Thread):
     def __init__(self, nodename: str, mqttc: mqtt.Client, output_topic: str,
                  path: str, weights_filename: str, image_buffer: ImageBuffer,
-                 save_csv: bool = True, visualize: bool = False):
+                 save_csv: bool = True, visualize: bool = False,
+                 tracknet_csv_path: str | None = None,
+                 kpt_radius: int = 3):
         super().__init__()
         self.nodename = nodename
         self.mqttc = mqttc
@@ -60,6 +63,16 @@ class YOLOPoseMqtt(threading.Thread):
         # warmup with one-frame input matching expected channels
         self.model.predictor.model.warmup(imgsz=(1, self.expected_ch, 640, 640))
         self.model.predictor.done_warmup = True
+        self.kpt_radius = kpt_radius
+        if tracknet_csv_path and os.path.exists(tracknet_csv_path):
+            try:
+                self.tracknet_df = pd.read_csv(tracknet_csv_path)
+            except Exception as e:
+                logging.warning(f"{self.nodename} failed to load tracknet CSV: {e}")
+                self.tracknet_df = None
+        else:
+            self.tracknet_df = None
+
         if save_csv:
             os.makedirs(path, exist_ok=True)
             csv_path = os.path.join(path, f"{self.nodename}.csv")
@@ -118,7 +131,13 @@ class YOLOPoseMqtt(threading.Thread):
                         self.csv_writer.write_row(frame.index, [float(v) for v in bbox],
                                                   kps, frame.monotonic_timestamp)
             if self.image_dir and results:
-                plotted = results[0].plot()
+                plotted = results[0].plot(kpt_radius=self.kpt_radius)
+                if self.tracknet_df is not None:
+                    row = self.tracknet_df[self.tracknet_df['Frame'] == frame.index]
+                    if not row.empty and int(row.iloc[0]['Visibility']) == 1:
+                        x = int(row.iloc[0]['X'])
+                        y = int(row.iloc[0]['Y'])
+                        cv2.circle(plotted, (x, y), 3, (0, 0, 255), -1)
                 img_path = os.path.join(self.image_dir, f"{frame.index:06d}.jpg")
                 cv2.imwrite(img_path, plotted)
             if points and self.mqttc is not None:

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -22,9 +22,12 @@ class PoseManager:
             replay_path = f"{ROOTDIR}/replay/{replay_dirname}"
             os.makedirs(replay_path, exist_ok=True)
 
+            tracknet_csv = os.path.join(replay_path, f"TrackNet_{cam_idx}.csv")
             self.poseThread = YOLOPoseMqtt(
                 f"Pose_{cam_idx}", self.mqttc, pose_topic, replay_path,
-                weights_filename, self.imageBuffer, True, visualize)
+                weights_filename, self.imageBuffer, True, visualize,
+                tracknet_csv_path=tracknet_csv,
+                kpt_radius=3)
             self.poseThread.start()
             return {"status": "ready"}
         except Exception as e:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -176,6 +176,7 @@ class Results(SimpleClass):
             boxes=True,
             masks=True,
             probs=True,
+            kpt_radius=5,
             **kwargs  # deprecated args TODO: remove support in 8.2
     ):
         """
@@ -194,6 +195,7 @@ class Results(SimpleClass):
             boxes (bool): Whether to plot the bounding boxes.
             masks (bool): Whether to plot the masks.
             probs (bool): Whether to plot classification probability
+            kpt_radius (int): Radius for keypoints drawing. Default is ``5``.
 
         Returns:
             (numpy.ndarray): A numpy array of the annotated image.
@@ -250,7 +252,7 @@ class Results(SimpleClass):
         # Plot Pose results
         if self.keypoints is not None:
             for k in reversed(self.keypoints.data):
-                annotator.kpts(k, self.orig_shape, kpt_line=kpt_line)
+                annotator.kpts(k, self.orig_shape, radius=kpt_radius, kpt_line=kpt_line)
 
         return annotator.result()
 


### PR DESCRIPTION
## Summary
- allow customizing keypoint radius in results plotting
- overlay TrackNet points on pose result images
- pass TrackNet CSV path through `PoseManager` to `YOLOPoseMqtt`

## Testing
- `python -m py_compile ultralytics/yolo/engine/results.py LayerSensing/Pose/YOLOPoseMqtt.py LayerSensing/PoseManager.py`

------
https://chatgpt.com/codex/tasks/task_e_68870300b6208323ab7e116c3aa5dfad