### PR TITLE
Add tracknet overlay in pose visualization

### DIFF
--- a/LayerSensing/Pose/YOLOPoseMqtt.py
+++ b/LayerSensing/Pose/YOLOPoseMqtt.py
@@ -23,6 +23,16 @@ class YOLOPoseMqtt(threading.Thread):
         self.output_topic = output_topic
         self.image_buffer = image_buffer
         self.visualize = visualize
+        # topic for receiving TrackNet points for visualization
+        self.device_name = output_topic.split('/')[2] if len(output_topic.split('/')) > 2 else ''
+        self.tracknet_topic = f"/DATA/{self.device_name}/LayerSensing/TrackNet"
+        self.tracknet_buffer = {}
+        self._tracknet_lock = threading.Lock()
+        try:
+            self.mqttc.message_callback_add(self.tracknet_topic, self._on_tracknet)
+            self.mqttc.subscribe(self.tracknet_topic)
+        except Exception as e:
+            logging.warning(f"{self.nodename} failed to subscribe TrackNet topic: {e}")
         weight_path = os.path.join(ROOTDIR, 'weights', weights_filename)
         self.model = YOLO(weight_path)
         # initialize predictor manually so we can warm up with the correct channel count
@@ -83,6 +93,18 @@ class YOLOPoseMqtt(threading.Thread):
         payload = {"linear": [p.toJson() for p in points]}
         self.mqttc.publish(self.output_topic, json.dumps(payload))
 
+    def _on_tracknet(self, client, userdata, msg):
+        try:
+            data = json.loads(msg.payload)
+            with self._tracknet_lock:
+                for p in data.get('linear', []):
+                    fid = int(p.get('id', -1))
+                    x = int(p['pos']['x'])
+                    y = int(p['pos']['y'])
+                    self.tracknet_buffer[fid] = (x, y)
+        except Exception as e:
+            logging.error(f"{self.nodename} tracknet parse error: {e}")
+
     def run(self):
         logging.info(f"{self.nodename} start processing...")
         while not self._stopped():
@@ -118,7 +140,11 @@ class YOLOPoseMqtt(threading.Thread):
                         self.csv_writer.write_row(frame.index, [float(v) for v in bbox],
                                                   kps, frame.monotonic_timestamp)
             if self.image_dir and results:
-                plotted = results[0].plot()
+                plotted = results[0].plot(kpt_radius=3)
+                with self._tracknet_lock:
+                    coord = self.tracknet_buffer.pop(frame.index, None)
+                if coord:
+                    cv2.circle(plotted, coord, 3, (0, 0, 255), -1)
                 img_path = os.path.join(self.image_dir, f"{frame.index:06d}.jpg")
                 cv2.imwrite(img_path, plotted)
             if points and self.mqttc is not None:

--- a/LayerSensing/Pose/YOLOPoseMqtt.py
+++ b/LayerSensing/Pose/YOLOPoseMqtt.py
@@ -5,6 +5,7 @@ import logging
 
 import cv2
 import paho.mqtt.client as mqtt
+from typing import Tuple
 from ultralytics import YOLO
 from ultralytics.yolo.v8.pose.predict import PosePredictor
 
@@ -105,7 +106,7 @@ class YOLOPoseMqtt(threading.Thread):
         except Exception as e:
             logging.error(f"{self.nodename} tracknet parse error: {e}")
 
-    def _apply_tracknet(self, fid: int, coord: tuple[int, int]):
+    def _apply_tracknet(self, fid: int, coord: Tuple[int, int]):
         """Store TrackNet result or draw directly if the image already exists."""
         if self.image_dir:
             img_path = os.path.join(self.image_dir, f"{fid:06d}.jpg")

--- a/LayerSensing/Pose/YOLOPoseMqtt.py
+++ b/LayerSensing/Pose/YOLOPoseMqtt.py
@@ -8,6 +8,7 @@ import paho.mqtt.client as mqtt
 from typing import Tuple
 from ultralytics import YOLO
 from ultralytics.yolo.v8.pose.predict import PosePredictor
+from ultralytics.yolo.utils.plotting import Annotator, colors
 
 from LayerCamera.CameraSystemC.recorder_module import ImageBuffer, Frame
 from lib.writer import PoseCSVWriter
@@ -118,6 +119,19 @@ class YOLOPoseMqtt(threading.Thread):
                     return
         self.tracknet_buffer[fid] = coord
 
+    def _draw_result(self, result, radius: int = 2):
+        """Return an annotated image with smaller keypoint radius."""
+        annotator = Annotator(result.orig_img.copy(), example=result.names)
+        if result.boxes is not None:
+            for d in reversed(result.boxes):
+                c = int(d.cls)
+                label = f"{result.names[c]} {float(d.conf):.2f}"
+                annotator.box_label(d.xyxy.squeeze(), label, color=colors(c, True))
+        if result.keypoints is not None:
+            for k in reversed(result.keypoints.data):
+                annotator.kpts(k, result.orig_shape, radius=radius, kpt_line=True)
+        return annotator.result()
+
     def run(self):
         logging.info(f"{self.nodename} start processing...")
         while not self._stopped():
@@ -153,7 +167,7 @@ class YOLOPoseMqtt(threading.Thread):
                         self.csv_writer.write_row(frame.index, [float(v) for v in bbox],
                                                   kps, frame.monotonic_timestamp)
             if self.image_dir and results:
-                plotted = results[0].plot(kpt_radius=2)
+                plotted = self._draw_result(results[0], radius=2)
                 with self._tracknet_lock:
                     coord = self.tracknet_buffer.pop(frame.index, None)
                 if coord:

--- a/LayerSensing/Pose/YOLOPoseMqtt.py
+++ b/LayerSensing/Pose/YOLOPoseMqtt.py
@@ -101,9 +101,21 @@ class YOLOPoseMqtt(threading.Thread):
                     fid = int(p.get('id', -1))
                     x = int(p['pos']['x'])
                     y = int(p['pos']['y'])
-                    self.tracknet_buffer[fid] = (x, y)
+                    self._apply_tracknet(fid, (x, y))
         except Exception as e:
             logging.error(f"{self.nodename} tracknet parse error: {e}")
+
+    def _apply_tracknet(self, fid: int, coord: tuple[int, int]):
+        """Store TrackNet result or draw directly if the image already exists."""
+        if self.image_dir:
+            img_path = os.path.join(self.image_dir, f"{fid:06d}.jpg")
+            if os.path.exists(img_path):
+                img = cv2.imread(img_path)
+                if img is not None:
+                    cv2.circle(img, coord, 2, (0, 0, 255), -1)
+                    cv2.imwrite(img_path, img)
+                    return
+        self.tracknet_buffer[fid] = coord
 
     def run(self):
         logging.info(f"{self.nodename} start processing...")
@@ -140,11 +152,11 @@ class YOLOPoseMqtt(threading.Thread):
                         self.csv_writer.write_row(frame.index, [float(v) for v in bbox],
                                                   kps, frame.monotonic_timestamp)
             if self.image_dir and results:
-                plotted = results[0].plot(kpt_radius=3)
+                plotted = results[0].plot(kpt_radius=2)
                 with self._tracknet_lock:
                     coord = self.tracknet_buffer.pop(frame.index, None)
                 if coord:
-                    cv2.circle(plotted, coord, 3, (0, 0, 255), -1)
+                    cv2.circle(plotted, coord, 2, (0, 0, 255), -1)
                 img_path = os.path.join(self.image_dir, f"{frame.index:06d}.jpg")
                 cv2.imwrite(img_path, plotted)
             if points and self.mqttc is not None:

--- a/ultralytics/yolo/engine/results.py
+++ b/ultralytics/yolo/engine/results.py
@@ -172,6 +172,7 @@ class Results(SimpleClass):
             img=None,
             im_gpu=None,
             kpt_line=True,
+            kpt_radius=5,
             labels=True,
             boxes=True,
             masks=True,
@@ -190,6 +191,7 @@ class Results(SimpleClass):
             img (numpy.ndarray): Plot to another image. if not, plot to original image.
             im_gpu (torch.Tensor): Normalized image in gpu with shape (1, 3, 640, 640), for faster mask plotting.
             kpt_line (bool): Whether to draw lines connecting keypoints.
+            kpt_radius (int): Radius of keypoint circles.
             labels (bool): Whether to plot the label of bounding boxes.
             boxes (bool): Whether to plot the bounding boxes.
             masks (bool): Whether to plot the masks.
@@ -250,7 +252,7 @@ class Results(SimpleClass):
         # Plot Pose results
         if self.keypoints is not None:
             for k in reversed(self.keypoints.data):
-                annotator.kpts(k, self.orig_shape, kpt_line=kpt_line)
+                annotator.kpts(k, self.orig_shape, radius=kpt_radius, kpt_line=kpt_line)
 
         return annotator.result()
 


### PR DESCRIPTION
## Summary
- allow specifying `kpt_radius` for YOLO results drawing
- shrink pose keypoint radius when saving images
- overlay TrackNet points on pose visualization images

## Testing
- `python3 -m py_compile LayerSensing/Pose/YOLOPoseMqtt.py ultralytics/yolo/engine/results.py`

------
https://chatgpt.com/codex/tasks/task_e_68870b24eadc83238597bd4fe91f600a