### PR TITLE
Add TrackNet visualization option

### DIFF
--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -1,31 +1,41 @@
 from lib.Rpc import RemoteProcedureCall
 
+
 class RpcSensing(RemoteProcedureCall):
     def __init__(self, device_name, mqtt_client):
         super().__init__(device_name, "SensingLayer", mqtt_client)
-        
-    def startTrackNet(self, camera_origin_size:'tuple[int, int]',
-                      tracknet_ver:str, weights_filename:str,
-                      replay_dirname:str, cam_idx: int):
+
+    def startTrackNet(
+        self,
+        camera_origin_size: "tuple[int, int]",
+        tracknet_ver: str,
+        weights_filename: str,
+        replay_dirname: str,
+        cam_idx: int,
+        visualize: bool = False,
+    ):
         """Start Tracknet thread
 
         Args:
             camera_origin_size (tuple[int, int]): 相機原始解析度 (Tracknet會回推)
             tracknet_ver (str): Tracknet版本 ("tracknet_v2" or "tracknet_1000")
             weights_filename (str): 模型檔案名稱
-            replay_dirname (str): 儲存的資料夾名稱 
+            replay_dirname (str): 儲存的資料夾名稱
             cam_idx (int): 相機編號
 
         Returns:
             dict: 狀態
         """
 
-        return self._call_rpc_sync("TrackNet/start",
-                                   camera_origin_size = camera_origin_size,
-                                   tracknet_ver=tracknet_ver,
-                                   weights_filename=weights_filename,
-                                   replay_dirname=replay_dirname,
-                                   cam_idx = cam_idx)
+        return self._call_rpc_sync(
+            "TrackNet/start",
+            camera_origin_size=camera_origin_size,
+            tracknet_ver=tracknet_ver,
+            weights_filename=weights_filename,
+            replay_dirname=replay_dirname,
+            cam_idx=cam_idx,
+            visualize=visualize,
+        )
 
     def stopTrackNet(self):
         """Stop Tracknet thread
@@ -41,8 +51,13 @@ class RpcSensing(RemoteProcedureCall):
     def stopDatafeeder(self):
         return self._call_rpc_sync("TrackNet/stopDatafeeder")
 
-    def startPose(self, weights_filename: str, replay_dirname: str, cam_idx: int,
-                  visualize: bool = False):
+    def startPose(
+        self,
+        weights_filename: str,
+        replay_dirname: str,
+        cam_idx: int,
+        visualize: bool = False,
+    ):
         """Start Pose thread"""
         return self._call_rpc_sync(
             "Pose/start",

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -1,6 +1,7 @@
 """
 TrackNet10 : find out the ball on frame on 2D Coordinate System
 """
+
 import logging
 import os
 import threading
@@ -23,12 +24,14 @@ HEIGHT = 288
 WIDTH = 512
 TRACK_SIZE = 10
 
-class BoundingBox():
+
+class BoundingBox:
     def __init__(self, left, top, right, bottom):
         self.left = left
         self.top = top
         self.right = right
         self.bottom = bottom
+
 
 def isBlacklist(boxs, x, y):
     for box in boxs:
@@ -36,36 +39,47 @@ def isBlacklist(boxs, x, y):
             return True
     return False
 
+
 def generateBlacklist(filename):
     blacklist = []
     with open(filename) as f:
         line = f.readline()
         while line:
             line = f.readline()
-            l = line.split(',')
+            l = line.split(",")
             if len(l) == 4:
                 b = BoundingBox(int(l[0]), int(l[1]), int(l[2]), int(l[3]))
                 blacklist.append(b)
     return blacklist
 
+
 class TrackNetThread:
-    def __init__(self, device:str, model:TrackNet10, mqttc:mqtt.Client,
-                 output_topic:str, blacklist,
-                 output_width:int, output_height:int,
-                 csv_writer:CSVWriter):
+    def __init__(
+        self,
+        device: str,
+        model: TrackNet10,
+        mqttc: mqtt.Client,
+        output_topic: str,
+        blacklist,
+        output_width: int,
+        output_height: int,
+        csv_writer: CSVWriter,
+        image_dir: str | None = None,
+    ):
 
         self.images = []
         self.fids = []
         self.timestamps = []
         self.device = device
         self.model = model
-        self.points:'list[Point]' = []
+        self.points: "list[Point]" = []
         self.blacklist = blacklist
         self.output_width = output_width
         self.output_height = output_height
         self.csv_writer = csv_writer
         self.mqttc = mqttc
         self.output_topic = output_topic
+        self.image_dir = image_dir
         # wait for new image
         self.isProcessing = False
         self.valid_size = 0
@@ -74,7 +88,7 @@ class TrackNetThread:
         self.images = []
         self.fids = []
         self.timestamps = []
-        self.points:'list[Point]' = []
+        self.points: "list[Point]" = []
         self.valid_size = 0
 
     def prediction(self):
@@ -100,8 +114,8 @@ class TrackNetThread:
             self.h_pred = self.model(unit)
         self.h_pred = self.h_pred > 0.5
         self.h_pred = self.h_pred.cpu().numpy()
-        self.h_pred = self.h_pred.astype('uint8')
-        self.h_pred = self.h_pred[0]*255
+        self.h_pred = self.h_pred.astype("uint8")
+        self.h_pred = self.h_pred[0] * 255
 
     def execute(self):
         # TrackNet
@@ -112,13 +126,26 @@ class TrackNetThread:
             # height, width, channels = image.shape
             ratio_w = self.output_width / WIDTH
             ratio_h = self.output_height / HEIGHT
-            #show = np.copy(image)
-            #show = cv2.resize(show, (width, height))
+            # show = np.copy(image)
+            # show = cv2.resize(show, (width, height))
             # Ball tracking
-            if np.amax(self.h_pred[idx_f]) <= 0: # no ball
-                point = Point(fid=fid, timestamp=timestamp, visibility=0, x=0, y=0, z=0, event=0, speed=0)
+            if np.amax(self.h_pred[idx_f]) <= 0:  # no ball
+                point = Point(
+                    fid=fid,
+                    timestamp=timestamp,
+                    visibility=0,
+                    x=0,
+                    y=0,
+                    z=0,
+                    event=0,
+                    speed=0,
+                )
             else:
-                (cnts, _) = cv2.findContours(self.h_pred[idx_f].copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+                (cnts, _) = cv2.findContours(
+                    self.h_pred[idx_f].copy(),
+                    cv2.RETR_EXTERNAL,
+                    cv2.CHAIN_APPROX_SIMPLE,
+                )
                 rects = [cv2.boundingRect(ctr) for ctr in cnts]
                 max_area_idx = 0
                 max_area = rects[max_area_idx][2] * rects[max_area_idx][3]
@@ -128,16 +155,44 @@ class TrackNetThread:
                         max_area_idx = i
                         max_area = area
                 target = rects[max_area_idx]
-                (cx_pred, cy_pred) = (int(ratio_w*(target[0] + target[2] / 2)), int(ratio_h*(target[1] + target[3] / 2)))
-                #logging.info("id: {} timestamp: {}, (x, y): ({}, {})".format(fid, timestamp, cx_pred, cy_pred))
-                if (not isBlacklist(self.blacklist, cx_pred, cy_pred)):
-                    point = Point(fid=fid, timestamp=timestamp, visibility=1, x=cx_pred, y=cy_pred, z=0, event=0, speed=0)
+                (cx_pred, cy_pred) = (
+                    int(ratio_w * (target[0] + target[2] / 2)),
+                    int(ratio_h * (target[1] + target[3] / 2)),
+                )
+                # logging.info("id: {} timestamp: {}, (x, y): ({}, {})".format(fid, timestamp, cx_pred, cy_pred))
+                if not isBlacklist(self.blacklist, cx_pred, cy_pred):
+                    point = Point(
+                        fid=fid,
+                        timestamp=timestamp,
+                        visibility=1,
+                        x=cx_pred,
+                        y=cy_pred,
+                        z=0,
+                        event=0,
+                        speed=0,
+                    )
                     insertById(self.points, point)
                 else:
-                    point = Point(fid=fid, timestamp=timestamp, visibility=0, x=0, y=0, z=0, event=0, speed=0)
+                    point = Point(
+                        fid=fid,
+                        timestamp=timestamp,
+                        visibility=0,
+                        x=0,
+                        y=0,
+                        z=0,
+                        event=0,
+                        speed=0,
+                    )
 
             if self.csv_writer is not None:
                 self.csv_writer.writePoints(point)
+            if self.image_dir is not None:
+                out = image.copy()
+                if out.ndim == 2:
+                    out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
+                color = (0, 255, 0) if point.visibility == 1 else (0, 0, 255)
+                cv2.circle(out, (int(point.x), int(point.y)), 5, color, -1)
+                cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
 
         if self.mqttc is not None:
             self.points = removeOutliers(self.points)
@@ -148,7 +203,7 @@ class TrackNetThread:
         self.mqttc.publish(self.output_topic, json.dumps(payload))
 
     def run(self):
-        #logging.debug("TrackNetThread started.")
+        # logging.debug("TrackNetThread started.")
         try:
             self.valid_size = len(self.images)
             if self.valid_size > 0:
@@ -162,19 +217,31 @@ class TrackNetThread:
                 self.prediction()
                 self.execute()
             else:
-                logging.warning("images size {} is not correctly. ".format(len(self.images)))
+                logging.warning(
+                    "images size {} is not correctly. ".format(len(self.images))
+                )
         except Exception as e:
             logging.error(e)
         finally:
             self.isProcessing = False
 
-        #logging.debug("TrackNetThread terminated.")
+        # logging.debug("TrackNetThread terminated.")
+
 
 class TrackNetMqtt(threading.Thread):
-    def __init__(self, nodename, mqttc:mqtt.Client, output_topic:str,
-                 camera_origin_width:int, camera_origin_height:int,
-                 path: str, weights_filename: str,
-                 imgbuf: ImageBuffer, save_csv=True):
+    def __init__(
+        self,
+        nodename,
+        mqttc: mqtt.Client,
+        output_topic: str,
+        camera_origin_width: int,
+        camera_origin_height: int,
+        path: str,
+        weights_filename: str,
+        imgbuf: ImageBuffer,
+        save_csv: bool = True,
+        visualize: bool = False,
+    ):
         """_summary_
 
         Args:
@@ -202,29 +269,37 @@ class TrackNetMqtt(threading.Thread):
         self.output_topic = output_topic
         self.mqttc = mqttc
 
+        replay_dir = path
         # Setup CSV Writer
         if save_csv:
-            path = os.path.join(path, self.nodename+'.csv')
-            self.csv_writer = CSVWriter(name=self.nodename, filename=path)
+            csv_path = os.path.join(replay_dir, self.nodename + ".csv")
+            self.csv_writer = CSVWriter(name=self.nodename, filename=csv_path)
         else:
             self.csv_writer = None
+        if visualize:
+            self.image_dir = os.path.join(replay_dir, "images")
+            os.makedirs(self.image_dir, exist_ok=True)
+        else:
+            self.image_dir = None
 
         self._stopper = threading.Event()
 
     def stop(self):
-        self._stopper.set()  
+        self._stopper.set()
 
     def _stopped(self):
         return self._stopper.is_set()
 
-    def _loadModel(self, weights_filename:str):
+    def _loadModel(self, weights_filename: str):
         ### Track Net Model ###
         model = TrackNet10()
         model.to(self.device)
 
-        weights = f"{ROOTDIR}/LayerSensing/TrackNet/TrackNet10/weights/{weights_filename}"
+        weights = (
+            f"{ROOTDIR}/LayerSensing/TrackNet/TrackNet10/weights/{weights_filename}"
+        )
         checkpoint = torch.load(weights)
-        model.load_state_dict(checkpoint['state_dict'])
+        model.load_state_dict(checkpoint["state_dict"])
         model.eval()
         self.model = model
 
@@ -235,14 +310,17 @@ class TrackNetMqtt(threading.Thread):
         list_timestamps = []
 
         # TrackNet
-        tracknetThread = TrackNetThread(device=self.device,
-                                        model=self.model,
-                                        mqttc=self.mqttc,
-                                        output_topic=self.output_topic,
-                                        blacklist=[],
-                                        output_width=self.camera_origin_width,
-                                        output_height=self.camera_origin_height,
-                                        csv_writer=self.csv_writer)
+        tracknetThread = TrackNetThread(
+            device=self.device,
+            model=self.model,
+            mqttc=self.mqttc,
+            output_topic=self.output_topic,
+            blacklist=[],
+            output_width=self.camera_origin_width,
+            output_height=self.camera_origin_height,
+            csv_writer=self.csv_writer,
+            image_dir=self.image_dir,
+        )
 
         while not self._stopped():
 
@@ -250,7 +328,9 @@ class TrackNetMqtt(threading.Thread):
                 frame = self.imageBuffer.pop(True)
                 if frame.is_eos:
                     if self.mqttc is not None:
-                        self.mqttc.publish(self.output_topic, json.dumps({"linear": [], "EOF": True}))
+                        self.mqttc.publish(
+                            self.output_topic, json.dumps({"linear": [], "EOF": True})
+                        )
                     logging.info(f"{self.nodename} EOF reached.")
                     self.stop()
                     break

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 import json
+from typing import Optional
 
 import cv2
 import numpy as np
@@ -64,7 +65,7 @@ class TrackNetThread:
         output_width: int,
         output_height: int,
         csv_writer: CSVWriter,
-        image_dir: str | None = None,
+        image_dir: Optional[str] = None,
     ):
 
         self.images = []

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
@@ -18,85 +18,113 @@ from ultralytics.yolo.utils import DEFAULT_CFG, LOGGER, SETTINGS, callbacks
 from ultralytics.yolo.utils.files import increment_path
 from ultralytics.yolo.utils.torch_utils import select_device
 import os
+
 DIRNAME = os.path.dirname(os.path.abspath(__file__))
 ROOTDIR = os.path.dirname(DIRNAME)
 
-def non_max_suppression(pred_conf, pred_x, pred_y, conf_threshold=0.5, dis_tolerance=10, stride=8):
-        """
-        Apply non-maximum suppression (NMS) to filter out overlapping balls based on distance.
-        
-        Args:
-        - pred_conf (torch.Tensor): 80x80 confidence tensor.
-        - pred_x (torch.Tensor): 80x80 x-coordinate tensor.
-        - pred_y (torch.Tensor): 80x80 y-coordinate tensor.
-        - conf_threshold (float): Confidence threshold.
-        - dis_tolerance (float): Minimum allowable distance between two detections.
-        
-        Returns:
-        - keep (list): List of (x, y, confidence) tuples for retained detections.
-        """
-        # 1. 篩選置信度 >= conf_threshold 的 cell
-        mask = pred_conf >= conf_threshold
-        conf_values = pred_conf[mask]
-        indices = torch.nonzero(mask)
 
-        # 2. 依照置信度降序排序
-        sorted_indices = torch.argsort(conf_values, descending=True)
-        sorted_conf_values = conf_values[sorted_indices]
-        sorted_positions = indices[sorted_indices]
+def non_max_suppression(
+    pred_conf, pred_x, pred_y, conf_threshold=0.5, dis_tolerance=10, stride=8
+):
+    """
+    Apply non-maximum suppression (NMS) to filter out overlapping balls based on distance.
 
-        # 3. 初始化結果列表
-        keep = []
-        result = []
-        center = stride/2
-        # 4. 應用距離檢查的 NMS
-        for i in range(len(sorted_conf_values)):
+    Args:
+    - pred_conf (torch.Tensor): 80x80 confidence tensor.
+    - pred_x (torch.Tensor): 80x80 x-coordinate tensor.
+    - pred_y (torch.Tensor): 80x80 y-coordinate tensor.
+    - conf_threshold (float): Confidence threshold.
+    - dis_tolerance (float): Minimum allowable distance between two detections.
 
-            y_coordinates, x_coordinates = sorted_positions[i].tolist()
-            x1 = center*stride - pred_x[y_coordinates][x_coordinates][0]+pred_x[y_coordinates][x_coordinates][1]
-            y1 = center*stride - pred_y[y_coordinates][x_coordinates][0]+pred_y[y_coordinates][x_coordinates][1]
-            conf = sorted_conf_values[i].item()
+    Returns:
+    - keep (list): List of (x, y, confidence) tuples for retained detections.
+    """
+    # 1. 篩選置信度 >= conf_threshold 的 cell
+    mask = pred_conf >= conf_threshold
+    conf_values = pred_conf[mask]
+    indices = torch.nonzero(mask)
 
-            x_coordinates *= stride
-            y_coordinates *= stride
-            current_x = x_coordinates+x1
-            current_y = y_coordinates+y1
+    # 2. 依照置信度降序排序
+    sorted_indices = torch.argsort(conf_values, descending=True)
+    sorted_conf_values = conf_values[sorted_indices]
+    sorted_positions = indices[sorted_indices]
 
-            # 只保留與所有已保留框距離大於 dis_tolerance 的框
-            is_far_enough = True
-            for x2, y2, _ in keep:
-                distance = torch.sqrt((current_x - x2) ** 2 + (current_y - y2) ** 2)
-                if distance < dis_tolerance:
-                    is_far_enough = False
-                    break
+    # 3. 初始化結果列表
+    keep = []
+    result = []
+    center = stride / 2
+    # 4. 應用距離檢查的 NMS
+    for i in range(len(sorted_conf_values)):
 
-            if is_far_enough:
-                keep.append((current_x, current_y, conf))
-                result.append((x_coordinates/stride, y_coordinates/stride, conf))
+        y_coordinates, x_coordinates = sorted_positions[i].tolist()
+        x1 = (
+            center * stride
+            - pred_x[y_coordinates][x_coordinates][0]
+            + pred_x[y_coordinates][x_coordinates][1]
+        )
+        y1 = (
+            center * stride
+            - pred_y[y_coordinates][x_coordinates][0]
+            + pred_y[y_coordinates][x_coordinates][1]
+        )
+        conf = sorted_conf_values[i].item()
 
-        return result
+        x_coordinates *= stride
+        y_coordinates *= stride
+        current_x = x_coordinates + x1
+        current_y = y_coordinates + y1
+
+        # 只保留與所有已保留框距離大於 dis_tolerance 的框
+        is_far_enough = True
+        for x2, y2, _ in keep:
+            distance = torch.sqrt((current_x - x2) ** 2 + (current_y - y2) ** 2)
+            if distance < dis_tolerance:
+                is_far_enough = False
+                break
+
+        if is_far_enough:
+            keep.append((current_x, current_y, conf))
+            result.append((x_coordinates / stride, y_coordinates / stride, conf))
+
+    return result
+
 
 class ImageBufferPredictor:
-    def __init__(self, weight: str, image_buffer: ImageBuffer, output_width: int = None,
-                 output_height: int = None, mqttc: mqtt.Client = None, output_topic: str = None,
-                 cfg=DEFAULT_CFG, overrides=None, path: str = None, save_pred_images: bool = False, use_nms: bool = True):
+    def __init__(
+        self,
+        weight: str,
+        image_buffer: ImageBuffer,
+        output_width: int = None,
+        output_height: int = None,
+        mqttc: mqtt.Client = None,
+        output_topic: str = None,
+        cfg=DEFAULT_CFG,
+        overrides=None,
+        path: str = None,
+        save_pred_images: bool = False,
+        use_nms: bool = True,
+    ):
 
         self.args = get_cfg(cfg, overrides)
         self.save_dir = path
+        if save_pred_images and self.save_dir:
+            os.makedirs(self.save_dir, exist_ok=True)
         weight = f"{ROOTDIR}/Tracknet1000/weights/best.pt"
-        self.model = AutoBackend(weight,
-                                 device=select_device(self.args.device, verbose=False),
-                                 dnn=self.args.dnn,
-                                 fp16=self.args.half,
-                                 fuse=True,
-                                 verbose=False)
+        self.model = AutoBackend(
+            weight,
+            device=select_device(self.args.device, verbose=False),
+            dnn=self.args.dnn,
+            fp16=self.args.half,
+            fuse=True,
+            verbose=False,
+        )
         self.device = self.model.device
         self.args.half = self.model.fp16
         self.model.eval()
 
         self.output_width = output_width
         self.output_height = output_height
-        print(f'[Predictor] Output size: {self.output_width}x{self.output_height}')
+        print(f"[Predictor] Output size: {self.output_width}x{self.output_height}")
 
         self.mqttc = mqttc
         self.output_topic = output_topic
@@ -105,7 +133,9 @@ class ImageBufferPredictor:
         self.imgsz = 640
 
         self.max_streams = torch.cuda.device_count() * 2
-        self.streams = [torch.cuda.Stream(device=self.device) for _ in range(self.max_streams)]
+        self.streams = [
+            torch.cuda.Stream(device=self.device) for _ in range(self.max_streams)
+        ]
         self.event_pool = queue.SimpleQueue()
         self.save_pred_images = save_pred_images
         self.use_nms = use_nms
@@ -142,7 +172,9 @@ class ImageBufferPredictor:
                 tensor, fids, timestamps = self._preprocess()
                 self.stream_idx = (self.stream_idx + 1) % self.max_streams
                 try:
-                    self.infer_q.put_nowait((tensor, (fids, timestamps), self.stream_idx))
+                    self.infer_q.put_nowait(
+                        (tensor, (fids, timestamps), self.stream_idx)
+                    )
                 except queue.Full:
                     LOGGER.warning("[Predictor] infer_q 已滿，無法放入新資料")
                 if not self.running:
@@ -156,7 +188,9 @@ class ImageBufferPredictor:
             frame = self.image_buffer.pop(True)
             if frame.is_eos:
                 self.stop()
-                self.mqttc.publish(self.output_topic, json.dumps({"linear": [], "EOF": True}))
+                self.mqttc.publish(
+                    self.output_topic, json.dumps({"linear": [], "EOF": True})
+                )
                 break
 
             # 目前傳入的尺寸不精確，在此額外處理
@@ -168,7 +202,9 @@ class ImageBufferPredictor:
             if img.ndim == 3:
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
             img = self.pad_to_square(img)
-            img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
+            img = cv2.resize(
+                img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC
+            )
             frames.append(np.expand_dims(img, axis=0))
             fids.append(frame.index)
             timestamps.append(frame.monotonic_timestamp)
@@ -235,7 +271,6 @@ class ImageBufferPredictor:
                 LOGGER.warning(f"Postprocess loop error: {e}")
                 raise e
 
-
     def pad_to_square(self, img: np.ndarray) -> np.ndarray:
         h, w = img.shape[:2]
         size = max(h, w)
@@ -243,7 +278,9 @@ class ImageBufferPredictor:
         padded[:h, :w] = img
         return padded
 
-    def _postprocess(self, output_tensor: torch.Tensor, meta:Tuple[List[int], List[float]]):
+    def _postprocess(
+        self, output_tensor: torch.Tensor, meta: Tuple[List[int], List[float]]
+    ):
         fids, timestamps = meta
 
         conf_threshold = 0.5
@@ -253,14 +290,15 @@ class ImageBufferPredictor:
         stride = 8
 
         feats = output_tensor[0][0]
-        pred_distri, pred_probs = feats.view(feat_no + nc, -1).split(
-            (feat_no, nc), 0)
-        
+        pred_distri, pred_probs = feats.view(feat_no + nc, -1).split((feat_no, nc), 0)
+
         pred_probs = pred_probs.permute(1, 0)
         pred_pos = pred_distri.permute(1, 0)
 
         each_probs = pred_probs.view(10, cell_num, cell_num)
-        each_pos_x, each_pos_y, each_pos_nx, each_pos_ny = pred_pos.view(10, cell_num, cell_num, feat_no).split([2, 2, 2, 2], dim=3)
+        each_pos_x, each_pos_y, each_pos_nx, each_pos_ny = pred_pos.view(
+            10, cell_num, cell_num, feat_no
+        ).split([2, 2, 2, 2], dim=3)
 
         frame_preds = []
         metadata = []
@@ -277,16 +315,32 @@ class ImageBufferPredictor:
             p_conf = each_probs[frame_idx]
             pred_local = []
             if self.use_nms:
-                nms_preds = non_max_suppression(p_conf, p_cell_x, p_cell_y, conf_threshold=conf_threshold, dis_tolerance=20)
+                nms_preds = non_max_suppression(
+                    p_conf,
+                    p_cell_x,
+                    p_cell_y,
+                    conf_threshold=conf_threshold,
+                    dis_tolerance=20,
+                )
 
                 # 取出 nms 的結果
                 for pred in nms_preds:
                     max_x, max_y, max_conf = pred
-                    pred_x = max_x*stride + (center*stride-p_cell_x[int(max_y)][int(max_x)][0]+p_cell_x[int(max_y)][int(max_x)][1])
-                    pred_y = max_y*stride + (center*stride-p_cell_y[int(max_y)][int(max_x)][0]+p_cell_y[int(max_y)][int(max_x)][1])
+                    pred_x = max_x * stride + (
+                        center * stride
+                        - p_cell_x[int(max_y)][int(max_x)][0]
+                        + p_cell_x[int(max_y)][int(max_x)][1]
+                    )
+                    pred_y = max_y * stride + (
+                        center * stride
+                        - p_cell_y[int(max_y)][int(max_x)][0]
+                        + p_cell_y[int(max_y)][int(max_x)][1]
+                    )
 
                     if fid != -1:
-                        real_result = self.convert_coord_to_original_ratio(coord=(pred_x.item(), pred_y.item(), max_conf))
+                        real_result = self.convert_coord_to_original_ratio(
+                            coord=(pred_x.item(), pred_y.item(), max_conf)
+                        )
                         frame_preds.append(real_result)
                         metadata.append((fid, timestamp))
                         if self.save_pred_images:
@@ -295,34 +349,50 @@ class ImageBufferPredictor:
                 p_conf_masked = p_conf * (p_conf >= conf_threshold).float()
                 max_position = torch.argmax(p_conf_masked)
                 # max_y, max_x = np.unravel_index(max_position, p_conf.shape)
-                max_y, max_x = np.unravel_index(max_position.cpu().numpy(), p_conf.shape)
+                max_y, max_x = np.unravel_index(
+                    max_position.cpu().numpy(), p_conf.shape
+                )
                 max_conf = p_conf[max_y, max_x].item()
                 if max_conf < conf_threshold:
                     continue
 
-                pred_x = max_x*stride + (center*stride-p_cell_x[max_y][max_x][0]+p_cell_x[max_y][max_x][1])
-                pred_y = max_y*stride + (center*stride-p_cell_y[max_y][max_x][0]+p_cell_y[max_y][max_x][1])
+                pred_x = max_x * stride + (
+                    center * stride
+                    - p_cell_x[max_y][max_x][0]
+                    + p_cell_x[max_y][max_x][1]
+                )
+                pred_y = max_y * stride + (
+                    center * stride
+                    - p_cell_y[max_y][max_x][0]
+                    + p_cell_y[max_y][max_x][1]
+                )
                 if fid != -1:
-                    real_result = self.convert_coord_to_original_ratio(coord=(pred_x.item(), pred_y.item(), max_conf))
+                    real_result = self.convert_coord_to_original_ratio(
+                        coord=(pred_x.item(), pred_y.item(), max_conf)
+                    )
                     frame_preds.append(real_result)
                     metadata.append((fid, timestamp))
                     if self.save_pred_images:
                         pred_local.append(real_result)
-            
+
             if self.save_pred_images:
                 img = self._frame_cache.get(fid)
-                self.save_image_with_points(pred_local, img, f"{self.save_dir}/{fid}.png")
+                self.save_image_with_points(
+                    pred_local, img, f"{self.save_dir}/{fid}.png"
+                )
 
         result = (frame_preds, metadata)
         if self.mqttc is not None:
-            self._publishPoints((frame_preds, metadata) if self.use_nms else (frame_preds[:1], metadata[:1]))
+            self._publishPoints(
+                (frame_preds, metadata)
+                if self.use_nms
+                else (frame_preds[:1], metadata[:1])
+            )
         # print("[Result] output shape:", len(frame_preds), "fid", fid, "timestamp", timestamp, "endTime", time.monotonic())
         return result
 
     def convert_coord_to_original_ratio(
-        self,
-        coord: Tuple[float, float, float],
-        model_input_size: int = 640
+        self, coord: Tuple[float, float, float], model_input_size: int = 640
     ) -> Tuple[float, float, float]:
         """
         將單一 (x, y, conf) 從 640x640 padding 空間還原到原始影像座標比例。
@@ -331,7 +401,7 @@ class ImageBufferPredictor:
         Args:
             coord: (x, y, conf)
             model_input_size: 模型輸入大小(預設 640)
-            
+
         Returns:
             (x_orig, y_orig, conf)
         """
@@ -351,8 +421,6 @@ class ImageBufferPredictor:
 
         return (x_orig, y_orig, conf)
 
-
-
     def _publishPoints(self, resultItems):
         (frame_preds, metadata) = resultItems
         points = []
@@ -360,19 +428,27 @@ class ImageBufferPredictor:
             (output_x, output_y, output_conf) = frame_preds[i]
             (fid, timestamp) = metadata[i]
 
-            points.append(Point(
-                fid=fid,
-                timestamp=timestamp,
-                visibility=output_conf>=0.5,
-                x=output_x,
-                y=output_y,
-                ))
+            points.append(
+                Point(
+                    fid=fid,
+                    timestamp=timestamp,
+                    visibility=output_conf >= 0.5,
+                    x=output_x,
+                    y=output_y,
+                )
+            )
         payload = {"linear": [p.toJson() for p in points]}
         self.mqttc.publish(self.output_topic, json.dumps(payload))
-    def save_image_with_points(self, points: List[Tuple[float, float, float]], image: np.ndarray, save_path: str):
+
+    def save_image_with_points(
+        self,
+        points: List[Tuple[float, float, float]],
+        image: np.ndarray,
+        save_path: str,
+    ):
         """
         將點集 (x, y, conf) 繪製到影像上，並保存到指定路徑。
-        
+
         Args:
             points (List[Tuple[float, float, float]]): [(x, y, conf), ...]
             image (np.ndarray): BGR 或灰階影像 (H, W, C) 或 (H, W)。

--- a/LayerSensing/TrackNet/Tracknet1000/Predict.py
+++ b/LayerSensing/TrackNet/Tracknet1000/Predict.py
@@ -1,6 +1,7 @@
 """
 TrackNet10 : find out the ball on frame on 2D Coordinate System
 """
+
 from datetime import datetime
 import logging
 import os
@@ -21,11 +22,21 @@ from lib.common import insertById, loadConfig, loadNodeConfig, ROOTDIR
 from lib.point import Point, removeOutliers
 from lib.writer import CSVWriter
 
+
 class TrackNet1000Mqtt(threading.Thread):
-    def __init__(self, nodename, mqttc:mqtt.Client, output_topic:str,
-                 camera_origin_width:int, camera_origin_height:int,
-                 path: str, weights_filename: str,
-                 imgbuf: ImageBuffer, save_csv=True):
+    def __init__(
+        self,
+        nodename,
+        mqttc: mqtt.Client,
+        output_topic: str,
+        camera_origin_width: int,
+        camera_origin_height: int,
+        path: str,
+        weights_filename: str,
+        imgbuf: ImageBuffer,
+        save_csv: bool = True,
+        visualize: bool = False,
+    ):
         """
         初始化 TrackNet1000 MQTT 推論執行緒。
 
@@ -57,10 +68,10 @@ class TrackNet1000Mqtt(threading.Thread):
         self.isProcessing = False
 
         overrides = {}
-        overrides['model'] = model_path
-        overrides['mode'] = 'predict_v2'
-        overrides['data'] = 'tracknet.yaml'
-        overrides['batch'] = 1
+        overrides["model"] = model_path
+        overrides["mode"] = "predict_v2"
+        overrides["data"] = "tracknet.yaml"
+        overrides["batch"] = 1
         self.predictor = ImageBufferPredictor.ImageBufferPredictor(
             weight=model_path,
             image_buffer=imgbuf,
@@ -70,6 +81,7 @@ class TrackNet1000Mqtt(threading.Thread):
             output_topic=output_topic,
             overrides=overrides,
             path=path,
+            save_pred_images=visualize,
         )
 
     def run(self):

--- a/LayerSensing/TrackNetManager.py
+++ b/LayerSensing/TrackNetManager.py
@@ -9,17 +9,24 @@ from LayerSensing.TrackNet.TrackNetMqtt import TrackNetMqtt
 from LayerSensing.Datafeeder import Datafeeder
 from lib.common import ROOTDIR
 
+
 class TrackNetManager:
-    def __init__(self, device_name, mqttc:mqtt.Client, imgbuf:ImageBuffer):
+    def __init__(self, device_name, mqttc: mqtt.Client, imgbuf: ImageBuffer):
 
         self.deviceName = device_name
         self.mqttc = mqttc
         self.imageBuffer = imgbuf
         self.tracknetThread = None
 
-    def startTrackNet(self, camera_origin_size: 'tuple[int, int]',
-                      tracknet_ver:str, weights_filename: str,
-                      replay_dirname: str, cam_idx: int):
+    def startTrackNet(
+        self,
+        camera_origin_size: "tuple[int, int]",
+        tracknet_ver: str,
+        weights_filename: str,
+        replay_dirname: str,
+        cam_idx: int,
+        visualize: bool = False,
+    ):
         """Start Tracknet thread
            會存在 PROJECT_ROOT/replay/{replay_dirname}/TrackNet_{cam_idx}.csv
 
@@ -27,8 +34,9 @@ class TrackNetManager:
             camera_origin_size (tuple[int, int]): 相機原始解析度 (Tracknet會回推)
             tracknet_ver (str): Tracknet版本 ("tracknet_v2" or "tracknet_1000")
             weights_filename (str): 模型檔案名稱
-            replay_dirname (str): 儲存的資料夾名稱 
+            replay_dirname (str): 儲存的資料夾名稱
             cam_idx (int): 相機編號
+            visualize (bool): 是否儲存帶有預測點的影像
 
         Returns:
             dict: 狀態
@@ -46,15 +54,31 @@ class TrackNetManager:
             os.makedirs(replay_path, exist_ok=True)
 
             if tracknet_ver == "tracknet_v2":
-                self.tracknetThread \
-                    = TrackNetMqtt(f"TrackNet_{cam_idx}", self.mqttc, tracknet_topic, camera_origin_size[0],
-                                   camera_origin_size[1], replay_path, weights_filename,
-                                   self.imageBuffer, True)
+                self.tracknetThread = TrackNetMqtt(
+                    f"TrackNet_{cam_idx}",
+                    self.mqttc,
+                    tracknet_topic,
+                    camera_origin_size[0],
+                    camera_origin_size[1],
+                    replay_path,
+                    weights_filename,
+                    self.imageBuffer,
+                    True,
+                    visualize,
+                )
             elif tracknet_ver == "tracknet_1000":
-                self.tracknetThread \
-                    = TrackNet1000Mqtt(f"TrackNet_{cam_idx}", self.mqttc, tracknet_topic, camera_origin_size[0],
-                                   camera_origin_size[1], replay_path, weights_filename,
-                                   self.imageBuffer, True)
+                self.tracknetThread = TrackNet1000Mqtt(
+                    f"TrackNet_{cam_idx}",
+                    self.mqttc,
+                    tracknet_topic,
+                    camera_origin_size[0],
+                    camera_origin_size[1],
+                    replay_path,
+                    weights_filename,
+                    self.imageBuffer,
+                    True,
+                    visualize,
+                )
             else:
                 raise Exception(f"tracknet_ver={tracknet_ver} is not acceptable.")
             self.tracknetThread.start()
@@ -74,7 +98,10 @@ class TrackNetManager:
                 self.imageBuffer.push(frame)
             self.tracknetThread.join()
             self.tracknetThread = None
-            return {"status": "stopped " + ("(EOS reached)" if wait_for_eos else "(Force stop)")}
+            return {
+                "status": "stopped "
+                + ("(EOS reached)" if wait_for_eos else "(Force stop)")
+            }
         except Exception as e:
             return {"status": "failure", "message": str(e)}
 

--- a/test_app.py
+++ b/test_app.py
@@ -22,13 +22,24 @@ sensing = RpcSensing("test-0", mqtt.mqttc)
 # save dir
 replay_dirname = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
+
 def startTask(use_tracknet: bool = False, use_pose: bool = False):
     if use_tracknet:
-        ret = sensing.startTrackNet((640, 480), "tracknet_v2", "no114_30.tar", replay_dirname, 0)
+        ret = sensing.startTrackNet(
+            (640, 480),
+            "tracknet_v2",
+            "no114_30.tar",
+            replay_dirname,
+            0,
+            visualize=True,
+        )
         print(f"TrackNet: {ret}")
     if use_pose:
-        ret = sensing.startPose("yolov8n-pose-gray-train.pt", replay_dirname, 0, visualize=True)
+        ret = sensing.startPose(
+            "yolov8n-pose-gray-train.pt", replay_dirname, 0, visualize=True
+        )
         print(f"Pose: {ret}")
+
 
 startTask(use_tracknet=True, use_pose=True)
 


### PR DESCRIPTION
## Summary
- add `visualize` argument to `startTrackNet` RPC and manager
- extend TrackNetMqtt and TrackNet1000Mqtt to save prediction images when visualizing
- support saving predicted frames in ImageBufferPredictor
- update `test_app` to enable TrackNet visualization

## Testing
- `python -m py_compile test_app.py LayerSensing/RpcSensing.py LayerSensing/TrackNetManager.py LayerSensing/TrackNet/TrackNetMqtt.py LayerSensing/TrackNet/Tracknet1000/Predict.py LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py`

------
https://chatgpt.com/codex/tasks/task_e_6888992887c08323ba22c5b88dd1ae5e