### PR TITLE
Add visualization option to TrackNet

### DIFF
--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -6,7 +6,8 @@ class RpcSensing(RemoteProcedureCall):
         
     def startTrackNet(self, camera_origin_size:'tuple[int, int]',
                       tracknet_ver:str, weights_filename:str,
-                      replay_dirname:str, cam_idx: int):
+                      replay_dirname:str, cam_idx: int,
+                      visualize: bool = False):
         """Start Tracknet thread
 
         Args:
@@ -20,12 +21,15 @@ class RpcSensing(RemoteProcedureCall):
             dict: 狀態
         """
 
-        return self._call_rpc_sync("TrackNet/start",
-                                   camera_origin_size = camera_origin_size,
-                                   tracknet_ver=tracknet_ver,
-                                   weights_filename=weights_filename,
-                                   replay_dirname=replay_dirname,
-                                   cam_idx = cam_idx)
+        return self._call_rpc_sync(
+            "TrackNet/start",
+            camera_origin_size=camera_origin_size,
+            tracknet_ver=tracknet_ver,
+            weights_filename=weights_filename,
+            replay_dirname=replay_dirname,
+            cam_idx=cam_idx,
+            visualize=visualize,
+        )
 
     def stopTrackNet(self):
         """Stop Tracknet thread

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -171,10 +171,19 @@ class TrackNetThread:
         #logging.debug("TrackNetThread terminated.")
 
 class TrackNetMqtt(threading.Thread):
-    def __init__(self, nodename, mqttc:mqtt.Client, output_topic:str,
-                 camera_origin_width:int, camera_origin_height:int,
-                 path: str, weights_filename: str,
-                 imgbuf: ImageBuffer, save_csv=True):
+    def __init__(
+        self,
+        nodename,
+        mqttc: mqtt.Client,
+        output_topic: str,
+        camera_origin_width: int,
+        camera_origin_height: int,
+        path: str,
+        weights_filename: str,
+        imgbuf: ImageBuffer,
+        save_csv: bool = True,
+        visualize: bool = False,
+    ):
         """_summary_
 
         Args:
@@ -186,6 +195,7 @@ class TrackNetMqtt(threading.Thread):
         threading.Thread.__init__(self)
 
         self.imageBuffer = imgbuf
+        self.visualize = visualize
 
         self.camera_origin_width = camera_origin_width
         self.camera_origin_height = camera_origin_height
@@ -202,12 +212,19 @@ class TrackNetMqtt(threading.Thread):
         self.output_topic = output_topic
         self.mqttc = mqttc
 
+        self.base_path = path
         # Setup CSV Writer
         if save_csv:
-            path = os.path.join(path, self.nodename+'.csv')
-            self.csv_writer = CSVWriter(name=self.nodename, filename=path)
+            csv_path = os.path.join(self.base_path, self.nodename + '.csv')
+            self.csv_writer = CSVWriter(name=self.nodename, filename=csv_path)
         else:
             self.csv_writer = None
+
+        if self.visualize:
+            self.image_dir = os.path.join(self.base_path, 'tracknet_images')
+            os.makedirs(self.image_dir, exist_ok=True)
+        else:
+            self.image_dir = None
 
         self._stopper = threading.Event()
 
@@ -269,6 +286,19 @@ class TrackNetMqtt(threading.Thread):
             tracknetThread.timestamps = list_timestamps.copy()
             tracknetThread.run()
 
+            if self.image_dir:
+                point_dict = {p.fid: p for p in tracknetThread.points}
+                for img, fid in zip(list_images, list_fids):
+                    if fid == -1:
+                        continue
+                    out = img.copy()
+                    if out.ndim == 2:
+                        out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
+                    p = point_dict.get(fid)
+                    if p and p.visibility:
+                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 255, 0), -1)
+                    cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
+
             list_images.clear()
             list_fids.clear()
             list_timestamps.clear()
@@ -281,6 +311,18 @@ class TrackNetMqtt(threading.Thread):
             tracknetThread.fids = list_fids.copy()
             tracknetThread.timestamps = list_timestamps.copy()
             tracknetThread.run()
+            if self.image_dir:
+                point_dict = {p.fid: p for p in tracknetThread.points}
+                for img, fid in zip(list_images, list_fids):
+                    if fid == -1:
+                        continue
+                    out = img.copy()
+                    if out.ndim == 2:
+                        out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
+                    p = point_dict.get(fid)
+                    if p and p.visibility:
+                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 255, 0), -1)
+                    cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
 
         if self.csv_writer is not None:
             self.csv_writer.close()

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -296,7 +296,7 @@ class TrackNetMqtt(threading.Thread):
                         out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
                     p = point_dict.get(fid)
                     if p and p.visibility:
-                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 0, 255), -1)
+                        cv2.circle(out, (int(p.x), int(p.y)), 2, (0, 0, 255), -1)
                     cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
 
             list_images.clear()
@@ -321,7 +321,7 @@ class TrackNetMqtt(threading.Thread):
                         out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
                     p = point_dict.get(fid)
                     if p and p.visibility:
-                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 0, 255), -1)
+                        cv2.circle(out, (int(p.x), int(p.y)), 2, (0, 0, 255), -1)
                     cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
 
         if self.csv_writer is not None:

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -289,14 +289,14 @@ class TrackNetMqtt(threading.Thread):
             if self.image_dir:
                 point_dict = {p.fid: p for p in tracknetThread.points}
                 for img, fid in zip(list_images, list_fids):
-                    if fid == -1:
+                    if fid == -1 or fid % 10 != 0:
                         continue
                     out = img.copy()
                     if out.ndim == 2:
                         out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
                     p = point_dict.get(fid)
                     if p and p.visibility:
-                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 255, 0), -1)
+                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 0, 255), -1)
                     cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
 
             list_images.clear()
@@ -314,14 +314,14 @@ class TrackNetMqtt(threading.Thread):
             if self.image_dir:
                 point_dict = {p.fid: p for p in tracknetThread.points}
                 for img, fid in zip(list_images, list_fids):
-                    if fid == -1:
+                    if fid == -1 or fid % 10 != 0:
                         continue
                     out = img.copy()
                     if out.ndim == 2:
                         out = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
                     p = point_dict.get(fid)
                     if p and p.visibility:
-                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 255, 0), -1)
+                        cv2.circle(out, (int(p.x), int(p.y)), 3, (0, 0, 255), -1)
                     cv2.imwrite(os.path.join(self.image_dir, f"{fid:06d}.jpg"), out)
 
         if self.csv_writer is not None:

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
@@ -309,7 +309,7 @@ class ImageBufferPredictor:
                     if self.save_pred_images:
                         pred_local.append(real_result)
             
-            if self.save_pred_images:
+            if self.save_pred_images and fid % 10 == 0:
                 img = self._frame_cache.get(fid)
                 self.save_image_with_points(pred_local, img, f"{self.save_dir}/{fid}.png")
 
@@ -384,10 +384,7 @@ class ImageBufferPredictor:
             img_vis = cv2.cvtColor(img_vis, cv2.COLOR_GRAY2BGR)
 
         for x, y, conf in points:
-            if conf < 0.5:
-                color = (0, 0, 255)  # 紅色，低信心
-            else:
-                color = (0, 255, 0)  # 綠色，正常
+            color = (0, 0, 255)
 
             center = (int(x), int(y))
             print(f"[Predictor] Drawing point at {center} with confidence {conf:.2f}")

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
@@ -388,6 +388,6 @@ class ImageBufferPredictor:
 
             center = (int(x), int(y))
             print(f"[Predictor] Drawing point at {center} with confidence {conf:.2f}")
-            cv2.circle(img_vis, center, radius=3, color=color, thickness=-1)
+            cv2.circle(img_vis, center, radius=2, color=color, thickness=-1)
 
         cv2.imwrite(save_path, img_vis)

--- a/LayerSensing/TrackNet/Tracknet1000/Predict.py
+++ b/LayerSensing/TrackNet/Tracknet1000/Predict.py
@@ -22,10 +22,19 @@ from lib.point import Point, removeOutliers
 from lib.writer import CSVWriter
 
 class TrackNet1000Mqtt(threading.Thread):
-    def __init__(self, nodename, mqttc:mqtt.Client, output_topic:str,
-                 camera_origin_width:int, camera_origin_height:int,
-                 path: str, weights_filename: str,
-                 imgbuf: ImageBuffer, save_csv=True):
+    def __init__(
+        self,
+        nodename,
+        mqttc: mqtt.Client,
+        output_topic: str,
+        camera_origin_width: int,
+        camera_origin_height: int,
+        path: str,
+        weights_filename: str,
+        imgbuf: ImageBuffer,
+        save_csv: bool = True,
+        visualize: bool = False,
+    ):
         """
         初始化 TrackNet1000 MQTT 推論執行緒。
 
@@ -56,11 +65,18 @@ class TrackNet1000Mqtt(threading.Thread):
         # wait for new image
         self.isProcessing = False
 
+        self.visualize = visualize
+
         overrides = {}
         overrides['model'] = model_path
         overrides['mode'] = 'predict_v2'
         overrides['data'] = 'tracknet.yaml'
         overrides['batch'] = 1
+
+        image_dir = os.path.join(path, 'tracknet_images') if visualize else path
+        if visualize:
+            os.makedirs(image_dir, exist_ok=True)
+
         self.predictor = ImageBufferPredictor.ImageBufferPredictor(
             weight=model_path,
             image_buffer=imgbuf,
@@ -69,7 +85,8 @@ class TrackNet1000Mqtt(threading.Thread):
             mqttc=mqttc,
             output_topic=output_topic,
             overrides=overrides,
-            path=path,
+            path=image_dir,
+            save_pred_images=visualize,
         )
 
     def run(self):

--- a/LayerSensing/TrackNetManager.py
+++ b/LayerSensing/TrackNetManager.py
@@ -17,9 +17,15 @@ class TrackNetManager:
         self.imageBuffer = imgbuf
         self.tracknetThread = None
 
-    def startTrackNet(self, camera_origin_size: 'tuple[int, int]',
-                      tracknet_ver:str, weights_filename: str,
-                      replay_dirname: str, cam_idx: int):
+    def startTrackNet(
+        self,
+        camera_origin_size: 'tuple[int, int]',
+        tracknet_ver: str,
+        weights_filename: str,
+        replay_dirname: str,
+        cam_idx: int,
+        visualize: bool = False,
+    ):
         """Start Tracknet thread
            會存在 PROJECT_ROOT/replay/{replay_dirname}/TrackNet_{cam_idx}.csv
 
@@ -46,15 +52,31 @@ class TrackNetManager:
             os.makedirs(replay_path, exist_ok=True)
 
             if tracknet_ver == "tracknet_v2":
-                self.tracknetThread \
-                    = TrackNetMqtt(f"TrackNet_{cam_idx}", self.mqttc, tracknet_topic, camera_origin_size[0],
-                                   camera_origin_size[1], replay_path, weights_filename,
-                                   self.imageBuffer, True)
+                self.tracknetThread = TrackNetMqtt(
+                    f"TrackNet_{cam_idx}",
+                    self.mqttc,
+                    tracknet_topic,
+                    camera_origin_size[0],
+                    camera_origin_size[1],
+                    replay_path,
+                    weights_filename,
+                    self.imageBuffer,
+                    True,
+                    visualize,
+                )
             elif tracknet_ver == "tracknet_1000":
-                self.tracknetThread \
-                    = TrackNet1000Mqtt(f"TrackNet_{cam_idx}", self.mqttc, tracknet_topic, camera_origin_size[0],
-                                   camera_origin_size[1], replay_path, weights_filename,
-                                   self.imageBuffer, True)
+                self.tracknetThread = TrackNet1000Mqtt(
+                    f"TrackNet_{cam_idx}",
+                    self.mqttc,
+                    tracknet_topic,
+                    camera_origin_size[0],
+                    camera_origin_size[1],
+                    replay_path,
+                    weights_filename,
+                    self.imageBuffer,
+                    True,
+                    visualize,
+                )
             else:
                 raise Exception(f"tracknet_ver={tracknet_ver} is not acceptable.")
             self.tracknetThread.start()

--- a/test_app.py
+++ b/test_app.py
@@ -24,7 +24,14 @@ replay_dirname = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
 def startTask(use_tracknet: bool = False, use_pose: bool = False):
     if use_tracknet:
-        ret = sensing.startTrackNet((640, 480), "tracknet_v2", "no114_30.tar", replay_dirname, 0)
+        ret = sensing.startTrackNet(
+            (640, 480),
+            "tracknet_v2",
+            "no114_30.tar",
+            replay_dirname,
+            0,
+            visualize=True,
+        )
         print(f"TrackNet: {ret}")
     if use_pose:
         ret = sensing.startPose("yolov8n-pose-gray-train.pt", replay_dirname, 0, visualize=True)


### PR DESCRIPTION
## Summary
- support `visualize` option for TrackNet RPC
- hook TrackNetMqtt and TrackNet1000Mqtt to save green dot images
- allow RpcSensing.startTrackNet to take `visualize` argument
- demonstrate in test_app

## Testing
- `python -m py_compile LayerSensing/RpcSensing.py LayerSensing/TrackNetManager.py LayerSensing/TrackNet/TrackNetMqtt.py LayerSensing/TrackNet/Tracknet1000/Predict.py test_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6889cee88a348323b0160b2e97c4654a