### PR TITLE
Add Pose data feeder implementation

### DIFF
--- a/LayerSensing/PoseDatafeeder.py
+++ b/LayerSensing/PoseDatafeeder.py
@@ -21,7 +21,8 @@ class PoseDatafeeder(threading.Thread):
         pose_topic = f"/DATA/{self.deviceName}/LayerSensing/Pose"
         df = pd.read_csv(self.filepath)
         if self.metapath:
-            self.meta_df = pd.read_csv(self.metapath)
+            # index the meta csv by frame so lookups by frame id are O(1)
+            self.meta_df = pd.read_csv(self.metapath, index_col=0)
         start = time.time()
         start_ts = float(df.iloc[0].Timestamp)
 

--- a/LayerSensing/PoseDatafeeder.py
+++ b/LayerSensing/PoseDatafeeder.py
@@ -1,0 +1,51 @@
+import threading
+import json
+import time
+import pandas as pd
+import paho.mqtt.client as mqtt
+
+from lib.point import Point
+
+class PoseDatafeeder(threading.Thread):
+    """Feed pose CSV results via MQTT similar to TrackNet Datafeeder."""
+
+    def __init__(self, mqttc: mqtt.Client, device_name: str, filepath: str, metapath: str | None = None):
+        super().__init__()
+        self.mqttc = mqttc
+        self.deviceName = device_name
+        self.filepath = filepath
+        self.metapath = metapath
+        self.meta_df = None
+
+    def run(self):
+        pose_topic = f"/DATA/{self.deviceName}/LayerSensing/Pose"
+        df = pd.read_csv(self.filepath)
+        if self.metapath:
+            self.meta_df = pd.read_csv(self.metapath)
+        start = time.time()
+        start_ts = float(df.iloc[0].Timestamp)
+
+        for frame_id, rows in df.groupby('Frame'):
+            payload = {"linear": []}
+            for _, row in rows.iterrows():
+                if self.meta_df is not None and row.Frame in self.meta_df.index:
+                    ts = self.meta_df.loc[row.Frame, 'monotonic_timestamp']
+                else:
+                    ts = row.Timestamp
+                point = Point(
+                    fid=row.Frame,
+                    timestamp=ts,
+                    visibility=1,
+                    x=row['kp1_x'],
+                    y=row['kp1_y'],
+                    z=0,
+                    event=0,
+                    speed=0,
+                )
+                payload['linear'].append(point.toJson())
+            while (time.time() - start) <= (rows.iloc[0].Timestamp - start_ts):
+                time.sleep(0.01)
+            self.mqttc.publish(pose_topic, json.dumps(payload))
+
+        self.mqttc.publish(pose_topic, json.dumps({"linear": [], "EOF": True}))
+        print(f"{pose_topic}: EOF")

--- a/LayerSensing/PoseDatafeeder.py
+++ b/LayerSensing/PoseDatafeeder.py
@@ -32,7 +32,8 @@ class PoseDatafeeder(threading.Thread):
             else:
                 ts = row.Timestamp
             payload = {
-                "Frame": int(row.Frame),
+                "id": int(row.Frame),
+                "timestamp": ts,
                 "bbox_x1": row["bbox_x1"],
                 "bbox_y1": row["bbox_y1"],
                 "bbox_x2": row["bbox_x2"],
@@ -41,7 +42,6 @@ class PoseDatafeeder(threading.Thread):
             for i in range(1, 18):
                 payload[f"kp{i}_x"] = row[f"kp{i}_x"]
                 payload[f"kp{i}_y"] = row[f"kp{i}_y"]
-            payload["Timestamp"] = ts
 
             while (time.time() - start) <= (row.Timestamp - start_ts):
                 time.sleep(0.01)

--- a/LayerSensing/PoseDatafeeder.py
+++ b/LayerSensing/PoseDatafeeder.py
@@ -6,8 +6,6 @@ from typing import Optional
 import pandas as pd
 import paho.mqtt.client as mqtt
 
-from lib.point import Point
-
 class PoseDatafeeder(threading.Thread):
     """Feed pose CSV results via MQTT similar to TrackNet Datafeeder."""
 
@@ -28,27 +26,26 @@ class PoseDatafeeder(threading.Thread):
         start = time.time()
         start_ts = float(df.iloc[0].Timestamp)
 
-        for frame_id, rows in df.groupby('Frame'):
-            payload = {"linear": []}
-            for _, row in rows.iterrows():
-                if self.meta_df is not None and row.Frame in self.meta_df.index:
-                    ts = self.meta_df.loc[row.Frame, 'monotonic_timestamp']
-                else:
-                    ts = row.Timestamp
-                point = Point(
-                    fid=row.Frame,
-                    timestamp=ts,
-                    visibility=1,
-                    x=row['kp1_x'],
-                    y=row['kp1_y'],
-                    z=0,
-                    event=0,
-                    speed=0,
-                )
-                payload['linear'].append(point.toJson())
-            while (time.time() - start) <= (rows.iloc[0].Timestamp - start_ts):
+        for _, row in df.iterrows():
+            if self.meta_df is not None and row.Frame in self.meta_df.index:
+                ts = self.meta_df.loc[row.Frame, 'monotonic_timestamp']
+            else:
+                ts = row.Timestamp
+            payload = {
+                "Frame": int(row.Frame),
+                "bbox_x1": row["bbox_x1"],
+                "bbox_y1": row["bbox_y1"],
+                "bbox_x2": row["bbox_x2"],
+                "bbox_y2": row["bbox_y2"],
+            }
+            for i in range(1, 18):
+                payload[f"kp{i}_x"] = row[f"kp{i}_x"]
+                payload[f"kp{i}_y"] = row[f"kp{i}_y"]
+            payload["Timestamp"] = ts
+
+            while (time.time() - start) <= (row.Timestamp - start_ts):
                 time.sleep(0.01)
             self.mqttc.publish(pose_topic, json.dumps(payload))
 
-        self.mqttc.publish(pose_topic, json.dumps({"linear": [], "EOF": True}))
+        self.mqttc.publish(pose_topic, json.dumps({"EOF": True}))
         print(f"{pose_topic}: EOF")

--- a/LayerSensing/PoseDatafeeder.py
+++ b/LayerSensing/PoseDatafeeder.py
@@ -1,6 +1,8 @@
 import threading
 import json
 import time
+from typing import Optional
+
 import pandas as pd
 import paho.mqtt.client as mqtt
 
@@ -9,7 +11,7 @@ from lib.point import Point
 class PoseDatafeeder(threading.Thread):
     """Feed pose CSV results via MQTT similar to TrackNet Datafeeder."""
 
-    def __init__(self, mqttc: mqtt.Client, device_name: str, filepath: str, metapath: str | None = None):
+    def __init__(self, mqttc: mqtt.Client, device_name: str, filepath: str, metapath: Optional[str] = None):
         super().__init__()
         self.mqttc = mqttc
         self.deviceName = device_name

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -1,4 +1,6 @@
 import os
+from typing import Optional
+
 import paho.mqtt.client as mqtt
 import pandas as pd
 
@@ -49,7 +51,7 @@ class PoseManager:
         except Exception as e:
             return {"status": "failure", "message": str(e)}
 
-    def startDatafeeder(self, filepath: str, metapath: str | None = None):
+    def startDatafeeder(self, filepath: str, metapath: Optional[str] = None):
         """Start a Pose CSV data feeder."""
         self.feederThread = PoseDatafeeder(self.mqttc, self.deviceName,
                                            filepath, metapath)

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -1,8 +1,10 @@
 import os
 import paho.mqtt.client as mqtt
+import pandas as pd
 
 from LayerCamera.CameraSystemC.recorder_module import ImageBuffer, Frame
 from LayerSensing.Pose.YOLOPoseMqtt import YOLOPoseMqtt
+from LayerSensing.PoseDatafeeder import PoseDatafeeder
 from lib.common import ROOTDIR
 
 class PoseManager:
@@ -11,6 +13,7 @@ class PoseManager:
         self.mqttc = mqttc
         self.imageBuffer = imgbuf
         self.poseThread = None
+        self.feederThread = None
 
     def startPose(self, weights_filename: str, replay_dirname: str, cam_idx: int,
                   visualize: bool = False):
@@ -45,3 +48,18 @@ class PoseManager:
             return {"status": "stopped " + ("(EOS reached)" if wait_for_eos else "(Force stop)")}
         except Exception as e:
             return {"status": "failure", "message": str(e)}
+
+    def startDatafeeder(self, filepath: str, metapath: str | None = None):
+        """Start a Pose CSV data feeder."""
+        self.feederThread = PoseDatafeeder(self.mqttc, self.deviceName,
+                                           filepath, metapath)
+        self.feederThread.start()
+
+        df = pd.read_csv(filepath)
+        duration = float(df.iloc[-1].Timestamp) - float(df.iloc[0].Timestamp)
+        return duration
+
+    def stopDatafeeder(self):
+        if self.feederThread is not None:
+            self.feederThread.join()
+            self.feederThread = None

--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from lib.Rpc import RemoteProcedureCall
 
 class RpcSensing(RemoteProcedureCall):
@@ -56,7 +58,7 @@ class RpcSensing(RemoteProcedureCall):
         """Stop Pose thread"""
         return self._call_rpc_sync("Pose/stop", timeout=1000)
 
-    def startPoseDatafeeder(self, filepath: str, metapath: str | None = None):
+    def startPoseDatafeeder(self, filepath: str, metapath: Optional[str] = None):
         return self._call_rpc_sync(
             "Pose/startDatafeeder", filepath=filepath, metapath=metapath
         )

--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -55,3 +55,11 @@ class RpcSensing(RemoteProcedureCall):
     def stopPose(self):
         """Stop Pose thread"""
         return self._call_rpc_sync("Pose/stop", timeout=1000)
+
+    def startPoseDatafeeder(self, filepath: str, metapath: str | None = None):
+        return self._call_rpc_sync(
+            "Pose/startDatafeeder", filepath=filepath, metapath=metapath
+        )
+
+    def stopPoseDatafeeder(self):
+        return self._call_rpc_sync("Pose/stopDatafeeder")

--- a/LayerSensing/SensingAgent.py
+++ b/LayerSensing/SensingAgent.py
@@ -44,3 +44,5 @@ class SensingLayerAgent(MqttAgent):
         super()._add_func_callback(self.tracknetManager.stopDatafeeder, "TrackNet/stopDatafeeder")
         super()._add_func_callback(self.poseManager.startPose, "Pose/start")
         super()._add_func_callback(self.poseManager.stopPose, "Pose/stop")
+        super()._add_func_callback(self.poseManager.startDatafeeder, "Pose/startDatafeeder")
+        super()._add_func_callback(self.poseManager.stopDatafeeder, "Pose/stopDatafeeder")

--- a/Tools/pose_datafeeder_receive.py
+++ b/Tools/pose_datafeeder_receive.py
@@ -1,0 +1,32 @@
+import argparse
+import json
+import paho.mqtt.client as mqtt
+
+
+def on_message(_client, _userdata, msg):
+    try:
+        payload = json.loads(msg.payload)
+    except json.JSONDecodeError:
+        payload = msg.payload.decode(errors="ignore")
+    print(f"[PoseData] {msg.topic}: {payload}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Receive pose data from MQTT and log it")
+    parser.add_argument("--broker", default="localhost", help="MQTT broker address")
+    parser.add_argument("--port", type=int, default=1883, help="MQTT broker port")
+    parser.add_argument("--device", required=True, help="Device name used in MQTT topics")
+    args = parser.parse_args()
+
+    topic = f"/DATA/{args.device}/LayerSensing/Pose"
+    mqttc = mqtt.Client()
+    mqttc.on_message = on_message
+    mqttc.connect(args.broker, args.port)
+    mqttc.subscribe(topic)
+
+    print(f"Listening on topic: {topic}")
+    mqttc.loop_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/pose_datafeeder_send.py
+++ b/Tools/pose_datafeeder_send.py
@@ -1,0 +1,28 @@
+import argparse
+import paho.mqtt.client as mqtt
+from LayerSensing.PoseDatafeeder import PoseDatafeeder
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send pose data via PoseDatafeeder")
+    parser.add_argument("--broker", default="localhost", help="MQTT broker address")
+    parser.add_argument("--port", type=int, default=1883, help="MQTT broker port")
+    parser.add_argument("--device", required=True, help="Device name used in MQTT topics")
+    parser.add_argument("--csv", required=True, help="Pose CSV file path")
+    parser.add_argument("--meta", help="Optional meta CSV file path")
+    args = parser.parse_args()
+
+    mqttc = mqtt.Client()
+    mqttc.connect(args.broker, args.port)
+    mqttc.loop_start()
+
+    feeder = PoseDatafeeder(mqttc, args.device, args.csv, args.meta)
+    feeder.start()
+    feeder.join()
+
+    mqttc.loop_stop()
+    mqttc.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `PoseDatafeeder` to publish pose CSV results over MQTT
- expose pose data feeder start/stop in `PoseManager`
- register pose data feeder RPC callbacks in `SensingLayerAgent`
- add RPC helper methods for pose data feeder

## Testing
- `python -m py_compile LayerSensing/PoseDatafeeder.py LayerSensing/PoseManager.py LayerSensing/SensingAgent.py LayerSensing/RpcSensing.py`
- `python test_app.py` *(fails: ModuleNotFoundError: No module named 'paho')*

------
https://chatgpt.com/codex/tasks/task_e_688a1cd0f50c8323ad880d54e1e11c0f