### PR TITLE
Add Pose data feeder implementation

### DIFF
--- a/LayerSensing/PoseDatafeeder.py
+++ b/LayerSensing/PoseDatafeeder.py
@@ -1,0 +1,51 @@
+import threading
+import json
+import time
+from typing import Optional
+
+import pandas as pd
+import paho.mqtt.client as mqtt
+
+class PoseDatafeeder(threading.Thread):
+    """Feed pose CSV results via MQTT similar to TrackNet Datafeeder."""
+
+    def __init__(self, mqttc: mqtt.Client, device_name: str, filepath: str, metapath: Optional[str] = None):
+        super().__init__()
+        self.mqttc = mqttc
+        self.deviceName = device_name
+        self.filepath = filepath
+        self.metapath = metapath
+        self.meta_df = None
+
+    def run(self):
+        pose_topic = f"/DATA/{self.deviceName}/LayerSensing/Pose"
+        df = pd.read_csv(self.filepath)
+        if self.metapath:
+            # index the meta csv by frame so lookups by frame id are O(1)
+            self.meta_df = pd.read_csv(self.metapath, index_col=0)
+        start = time.time()
+        start_ts = float(df.iloc[0].Timestamp)
+
+        for _, row in df.iterrows():
+            if self.meta_df is not None and row.Frame in self.meta_df.index:
+                ts = self.meta_df.loc[row.Frame, 'monotonic_timestamp']
+            else:
+                ts = row.Timestamp
+            payload = {
+                "id": int(row.Frame),
+                "timestamp": ts,
+                "bbox_x1": row["bbox_x1"],
+                "bbox_y1": row["bbox_y1"],
+                "bbox_x2": row["bbox_x2"],
+                "bbox_y2": row["bbox_y2"],
+            }
+            for i in range(1, 18):
+                payload[f"kp{i}_x"] = row[f"kp{i}_x"]
+                payload[f"kp{i}_y"] = row[f"kp{i}_y"]
+
+            while (time.time() - start) <= (row.Timestamp - start_ts):
+                time.sleep(0.01)
+            self.mqttc.publish(pose_topic, json.dumps(payload))
+
+        self.mqttc.publish(pose_topic, json.dumps({"EOF": True}))
+        print(f"{pose_topic}: EOF")

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -1,8 +1,12 @@
 import os
+from typing import Optional
+
 import paho.mqtt.client as mqtt
+import pandas as pd
 
 from LayerCamera.CameraSystemC.recorder_module import ImageBuffer, Frame
 from LayerSensing.Pose.YOLOPoseMqtt import YOLOPoseMqtt
+from LayerSensing.PoseDatafeeder import PoseDatafeeder
 from lib.common import ROOTDIR
 
 class PoseManager:
@@ -11,6 +15,7 @@ class PoseManager:
         self.mqttc = mqttc
         self.imageBuffer = imgbuf
         self.poseThread = None
+        self.feederThread = None
 
     def startPose(self, weights_filename: str, replay_dirname: str, cam_idx: int,
                   visualize: bool = False):
@@ -45,3 +50,18 @@ class PoseManager:
             return {"status": "stopped " + ("(EOS reached)" if wait_for_eos else "(Force stop)")}
         except Exception as e:
             return {"status": "failure", "message": str(e)}
+
+    def startDatafeeder(self, filepath: str, metapath: Optional[str] = None):
+        """Start a Pose CSV data feeder."""
+        self.feederThread = PoseDatafeeder(self.mqttc, self.deviceName,
+                                           filepath, metapath)
+        self.feederThread.start()
+
+        df = pd.read_csv(filepath)
+        duration = float(df.iloc[-1].Timestamp) - float(df.iloc[0].Timestamp)
+        return duration
+
+    def stopDatafeeder(self):
+        if self.feederThread is not None:
+            self.feederThread.join()
+            self.feederThread = None

--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from lib.Rpc import RemoteProcedureCall
 
 class RpcSensing(RemoteProcedureCall):
@@ -55,3 +57,11 @@ class RpcSensing(RemoteProcedureCall):
     def stopPose(self):
         """Stop Pose thread"""
         return self._call_rpc_sync("Pose/stop", timeout=1000)
+
+    def startPoseDatafeeder(self, filepath: str, metapath: Optional[str] = None):
+        return self._call_rpc_sync(
+            "Pose/startDatafeeder", filepath=filepath, metapath=metapath
+        )
+
+    def stopPoseDatafeeder(self):
+        return self._call_rpc_sync("Pose/stopDatafeeder")

--- a/LayerSensing/SensingAgent.py
+++ b/LayerSensing/SensingAgent.py
@@ -44,3 +44,5 @@ class SensingLayerAgent(MqttAgent):
         super()._add_func_callback(self.tracknetManager.stopDatafeeder, "TrackNet/stopDatafeeder")
         super()._add_func_callback(self.poseManager.startPose, "Pose/start")
         super()._add_func_callback(self.poseManager.stopPose, "Pose/stop")
+        super()._add_func_callback(self.poseManager.startDatafeeder, "Pose/startDatafeeder")
+        super()._add_func_callback(self.poseManager.stopDatafeeder, "Pose/stopDatafeeder")

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ make run-camera
 make run-device-monitor-daemon
 ```
 
+## Pose data feeder scripts
+
+Publish pose CSV results over MQTT:
+
+```bash
+python3 ./Tools/pose_datafeeder_receive.py --device 1
+python3 ./Tools/pose_datafeeder_send.py --device 1 --csv /workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv
+```
+
+Run the receiver before starting the sender.
+
 ## Notice
 
 1. 有插新相機的話需要重開

--- a/Tools/pose_datafeeder_receive.py
+++ b/Tools/pose_datafeeder_receive.py
@@ -1,0 +1,35 @@
+import argparse
+import json
+import time
+from LayerApplication.utils.Mqtt import MqttClient
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Receive pose data over MQTT")
+    parser.add_argument("--device", required=True, help="device name or id")
+    parser.add_argument("--broker", default="localhost", help="MQTT broker address")
+    parser.add_argument("--port", type=int, default=1885, help="MQTT broker port")
+    args = parser.parse_args()
+
+    mqtt_client = MqttClient(args.broker, args.port)
+    topic = f"/DATA/{args.device}/LayerSensing/Pose"
+    mqtt_client.mqttc.subscribe(topic)
+
+    def on_message(client, userdata, msg):
+        try:
+            print(json.loads(msg.payload))
+        except json.JSONDecodeError:
+            print(msg.payload)
+
+    mqtt_client.mqttc.on_message = on_message
+    print(f"Subscribed to {topic}. Waiting for messages...")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    mqtt_client.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/pose_datafeeder_send.py
+++ b/Tools/pose_datafeeder_send.py
@@ -1,0 +1,24 @@
+import argparse
+from LayerApplication.utils.Mqtt import MqttClient
+from LayerSensing.PoseManager import PoseManager
+from LayerCamera.CameraSystemC.recorder_module import ImageBuffer
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send pose CSV data over MQTT")
+    parser.add_argument("--device", required=True, help="device name or id")
+    parser.add_argument("--csv", required=True, help="pose CSV file path")
+    parser.add_argument("--meta", help="optional meta CSV file for timestamps")
+    parser.add_argument("--broker", default="localhost", help="MQTT broker address")
+    parser.add_argument("--port", type=int, default=1885, help="MQTT broker port")
+    args = parser.parse_args()
+
+    mqtt_client = MqttClient(args.broker, args.port)
+    pose_manager = PoseManager(str(args.device), mqtt_client.mqttc, ImageBuffer())
+    pose_manager.startDatafeeder(args.csv, args.meta)
+    pose_manager.stopDatafeeder()
+    mqtt_client.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,17 @@ make run-camera
 make run-device-monitor-daemon
 ```
 
+## Pose data feeder scripts
+
+Publish pose CSV results over MQTT:
+
+```bash
+python3 ./Tools/pose_datafeeder_receive.py --device 1
+python3 ./Tools/pose_datafeeder_send.py --device 1 --csv /workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv
+```
+
+Run the receiver before starting the sender.
+
 ## Notice
 
 1. 有插新相機的話需要重開


### PR DESCRIPTION
## Summary
- implement `PoseDatafeeder` to publish pose CSV results over MQTT
- expose pose data feeder start/stop in `PoseManager`, RPC layers, and agent
- index meta CSV by frame for efficient timestamp lookups
- switch to `Optional[str]` annotations for Python <3.10 compatibility
- format pose feed messages with id, timestamp, bbox and keypoint pairs
- add CLI scripts to send and receive pose data over MQTT and document usage

## Testing
- `python -m py_compile LayerSensing/PoseDatafeeder.py LayerSensing/PoseManager.py LayerSensing/SensingAgent.py LayerSensing/RpcSensing.py Tools/pose_datafeeder_send.py Tools/pose_datafeeder_receive.py`
- `pip install paho-mqtt` *(fails: Could not find a version that satisfies the requirement paho-mqtt (403 Forbidden))*
- `python test_app.py` *(fails: ModuleNotFoundError: No module named 'paho')*


------
https://chatgpt.com/codex/tasks/task_e_688a1cd0f50c8323ad880d54e1e11c0f