### PR TITLE
Add pose datafeeder helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ make run-camera
 make run-device-monitor-daemon
 ```
 
+* Pose Data Feeder
+
+```bash
+bash Tools/pose_datafeeder.sh 1 /workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv
+```
+
 ## Notice
 
 1. 有插新相機的話需要重開
@@ -75,4 +81,4 @@ python LayerCamera/camera/RpcCamera.py
 	* apt source using `free.nchc.org.tw` for faster speed
 	* add psutil to `requirements.txt`
 * v1.3
-	* add pyqtgraph to `requirements.txt`
+* add pyqtgraph to `requirements.txt`

--- a/Tools/pose_datafeeder.sh
+++ b/Tools/pose_datafeeder.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: Tools/pose_datafeeder.sh <device> <csv_path>
+# Example:
+#   Tools/pose_datafeeder.sh 1 /workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv
+
+DEVICE=${1:-1}
+CSV_PATH=${2:-/workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv}
+
+# Resolve directory of this script so it works from any working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Start the receiver first so it is ready for incoming data.
+python3 "$SCRIPT_DIR/pose_datafeeder_receive.py" --device "$DEVICE" &
+RECEIVER_PID=$!
+
+# Give the receiver a moment to connect before sending data.
+sleep 1
+
+# Send pose data from the CSV file.
+python3 "$SCRIPT_DIR/pose_datafeeder_send.py" --device "$DEVICE" --csv "$CSV_PATH"
+
+# Wait for the receiver to finish processing.
+wait $RECEIVER_PID

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,12 @@ make run-camera
 make run-device-monitor-daemon
 ```
 
+* Pose Data Feeder
+
+```bash
+bash Tools/pose_datafeeder.sh 1 /workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv
+```
+
 ## Notice
 
 1. 有插新相機的話需要重開
@@ -72,4 +78,4 @@ python LayerCamera/camera/RpcCamera.py
 	* apt source using `free.nchc.org.tw` for faster speed
 	* add psutil to `requirements.txt`
 * v1.3
-	* add pyqtgraph to `requirements.txt`
+* add pyqtgraph to `requirements.txt`


### PR DESCRIPTION
## Summary
- add bash script to run pose datafeeder receiver then sender

## Testing
- `python3 Tools/pose_datafeeder_receive.py --device 1` *(fails: ModuleNotFoundError: No module named 'paho')*
- `pip install paho-mqtt pandas` *(fails: Could not find a version that satisfies the requirement paho-mqtt (proxy 403))*
- `apt-get install -y python3-paho-mqtt python3-pandas python3-opencv python3-requests` *(fails: Unable to locate package python3-paho-mqtt)*
- `bash Tools/pose_datafeeder.sh 1 /workspaces/CameraSensor/replay/2025-07-31_16-54-02/Pose_0.csv` *(fails: ModuleNotFoundError: No module named 'paho')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2'; ModuleNotFoundError: No module named 'paho'; ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68906c23e8dc8323903d1b88a7b2675b