### PR TITLE
feat: make pose fps configurable

### DIFF
--- a/LayerSensing/FrameDistributor.py
+++ b/LayerSensing/FrameDistributor.py
@@ -9,12 +9,21 @@ class FrameDistributor(threading.Thread):
     """
 
     def __init__(self, src_buf: ImageBuffer, tracknet_buf: ImageBuffer,
-                 pose_buf: ImageBuffer, pose_interval: int = 4):
+                 pose_buf: ImageBuffer, pose_fps: int = 30, src_fps: int = 120):
+        """Initialize distributor with target pose FPS.
+
+        Args:
+            src_buf (ImageBuffer): Source frames.
+            tracknet_buf (ImageBuffer): Destination buffer for TrackNet.
+            pose_buf (ImageBuffer): Destination buffer for Pose.
+            pose_fps (int, optional): Desired pose frames per second, e.g. 120, 60, 40, 30, 20.
+            src_fps (int, optional): Source camera FPS. Defaults to 120.
+        """
         super().__init__()
         self.src_buf = src_buf
         self.tracknet_buf = tracknet_buf
         self.pose_buf = pose_buf
-        self.pose_interval = pose_interval
+        self.pose_interval = max(1, src_fps // pose_fps)
         self._stopper = threading.Event()
 
     def stop(self):

--- a/LayerSensing/SensingAgent.py
+++ b/LayerSensing/SensingAgent.py
@@ -8,7 +8,14 @@ from LayerSensing.PoseManager import PoseManager
 from LayerSensing.FrameDistributor import FrameDistributor
 
 class SensingLayerAgent(MqttAgent):
-    def __init__(self, device_name:str, imgbuf: ImageBuffer):
+    def __init__(self, device_name:str, imgbuf: ImageBuffer, pose_fps: int = 30):
+        """Initialize sensing layer with configurable pose frame rate.
+
+        Args:
+            device_name (str): Device identifier.
+            imgbuf (ImageBuffer): Source image buffer from camera.
+            pose_fps (int, optional): Target FPS for pose estimation. Valid values: 120, 60, 40, 30, 20.
+        """
         super().__init__(device_name, "SensingLayer")
 
         # create internal buffers for tracknet and pose
@@ -16,11 +23,10 @@ class SensingLayerAgent(MqttAgent):
         self._tracknet_buf = ImageBuffer()
         self._pose_buf = ImageBuffer()
         # distribute frames from the camera to TrackNet and Pose
-        # Pose only receives every 4th frame
         self._distributor = FrameDistributor(self._src_buf,
                                              self._tracknet_buf,
                                              self._pose_buf,
-                                             pose_interval=4)
+                                             pose_fps=pose_fps)
 
         self.tracknetManager = TrackNetManager(device_name, self.mqttc, self._tracknet_buf)
         self.poseManager = PoseManager(device_name, self.mqttc, self._pose_buf)

--- a/main_device.py
+++ b/main_device.py
@@ -12,6 +12,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("name", help="host name")
     parser.add_argument("serial", help="camera serial")
+    parser.add_argument("--pose-fps", type=int, default=30,
+                        help="pose estimation FPS, options: 120, 60, 40, 30, 20")
     args = parser.parse_args()
 
     # loading project config
@@ -21,11 +23,13 @@ if __name__ == "__main__":
     broker_port = int(cfg["Project"]["mqtt_port"])
 
     device_name = args.name
+    pose_fps = args.pose_fps  # supported pose fps: 120, 60, 40, 30, 20
 
     cameraAgent = CameraLayerAgent(device_name, args.serial)
     cameraAgent.start(broker_ip, broker_port)
 
-    sensingAgent = SensingLayerAgent(device_name, cameraAgent.camera.getImageBuffer())
+    sensingAgent = SensingLayerAgent(device_name, cameraAgent.camera.getImageBuffer(),
+                                     pose_fps=pose_fps)
     sensingAgent.start(broker_ip, broker_port)
 
     logging.info(f"{__file__} started.")

--- a/main_device.py
+++ b/main_device.py
@@ -12,8 +12,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("name", help="host name")
     parser.add_argument("serial", help="camera serial")
-    parser.add_argument("--pose-fps", type=int, default=30,
-                        help="pose estimation FPS, options: 120, 60, 40, 30, 20")
+    parser.add_argument(
+        "pose_fps",
+        type=int,
+        nargs="?",
+        default=30,
+        help="pose estimation FPS, options: 120, 60, 40, 30, 20",
+    )
     args = parser.parse_args()
 
     # loading project config


### PR DESCRIPTION
## Summary
- allow FrameDistributor to compute pose frame distribution based on configurable FPS
- expose pose FPS parameter through SensingLayerAgent and main_device CLI

## Testing
- `pytest -q` (fails: No module named 'cv2')
- `pip install opencv-python paho-mqtt requests` (fails: Could not find a version that satisfies the requirement opencv-python)


------
https://chatgpt.com/codex/tasks/task_e_68919790aedc8323809d8c0f8dab59dc