### PR TITLE
dev_mqtt: Add TensorRT pose inference support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,9 @@ ENV PATH="/home/${USERNAME}/miniconda3/bin/:$PATH"
 
 COPY requirements.txt /home/${USERNAME}/requirements.txt
 
+RUN pip3 install --upgrade pip
 RUN pip3 install -r ~/requirements.txt
+RUN pip3 install --no-cache-dir --extra-index-url https://pypi.ngc.nvidia.com nvidia-tensorrt
 
 # Fix: ImportError: /home/nol/miniconda3/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /workspaces/camerasensor/LayerCamera/CameraSystemC/recorder_module.cpython-38-x86_64-linux-gnu.so)
 RUN conda install -c conda-forge -y libstdcxx-ng=12

--- a/LayerSensing/Pose/__init__.py
+++ b/LayerSensing/Pose/__init__.py
@@ -1,0 +1,13 @@
+"""TensorRT-based YOLOv8 pose inference helpers."""
+
+from .pose_worker import PoseWorker
+from .pose_mqtt import PoseMqtt
+from .tensorrt_engine import TensorRTPoseEngine, PoseDetection, PoseInferenceResult
+
+__all__ = [
+    "PoseWorker",
+    "PoseMqtt",
+    "TensorRTPoseEngine",
+    "PoseDetection",
+    "PoseInferenceResult",
+]

--- a/LayerSensing/Pose/pose_mqtt.py
+++ b/LayerSensing/Pose/pose_mqtt.py
@@ -1,0 +1,42 @@
+"""Convenience wrapper mirroring the TrackNet MQTT predictor interface."""
+from __future__ import annotations
+
+from typing import Any
+
+from LayerCamera.CameraSystemC.recorder_module import ImageBuffer
+
+from .pose_worker import PoseWorker
+
+
+class PoseMqtt(PoseWorker):
+    """Drop-in replacement for TrackNet MQTT threads that performs pose inference."""
+
+    def __init__(
+        self,
+        nodename: str,
+        mqtt_client: Any,
+        data_handler: Any,
+        image_buffer: ImageBuffer,
+        engine_path: str,
+        *,
+        camera_index: int,
+        input_size: int = 640,
+        conf_threshold: float = 0.25,
+        iou_threshold: float = 0.65,
+        max_det: int = 100,
+    ) -> None:
+        super().__init__(
+            nodename,
+            image_buffer,
+            data_handler,
+            mqtt_client,
+            engine_path,
+            camera_index=camera_index,
+            input_size=input_size,
+            conf_threshold=conf_threshold,
+            iou_threshold=iou_threshold,
+            max_det=max_det,
+        )
+
+
+__all__ = ["PoseMqtt"]

--- a/LayerSensing/Pose/pose_worker.py
+++ b/LayerSensing/Pose/pose_worker.py
@@ -1,0 +1,101 @@
+"""Worker thread that consumes frames and publishes TensorRT pose results."""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any, Dict
+
+from LayerCamera.CameraSystemC.recorder_module import Frame, ImageBuffer
+
+from .tensorrt_engine import PoseInferenceResult, TensorRTPoseEngine
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PoseWorker(threading.Thread):
+    """Consumes frames from an :class:`ImageBuffer` and publishes pose estimates."""
+
+    def __init__(
+        self,
+        nodename: str,
+        image_buffer: ImageBuffer,
+        data_handler: Any,
+        _mqtt_client: Any,
+        engine_path: str,
+        *,
+        camera_index: int,
+        input_size: int = 640,
+        conf_threshold: float = 0.25,
+        iou_threshold: float = 0.65,
+        max_det: int = 100,
+    ) -> None:
+        super().__init__(daemon=True)
+        self.nodename = nodename
+        self.image_buffer = image_buffer
+        self.data_handler = data_handler
+        self.camera_index = camera_index
+        self.stop_event = threading.Event()
+
+        self.engine = TensorRTPoseEngine(
+            engine_path,
+            input_shape=(3, input_size, input_size),
+            conf_threshold=conf_threshold,
+            iou_threshold=iou_threshold,
+            max_det=max_det,
+        )
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        LOGGER.info("%s pose worker started", self.nodename)
+        try:
+            while not self.stop_event.is_set():
+                frame = self.image_buffer.pop(True)
+                if frame is None:
+                    continue
+                if frame.is_eos:
+                    LOGGER.info("%s pose worker received EOS", self.nodename)
+                    break
+                try:
+                    result = self.engine.predict(frame.image)
+                    payload = self._format_payload(frame, result)
+                    self.data_handler.publish("pose", json.dumps(payload))
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    LOGGER.exception("Pose inference failed: %s", exc)
+        finally:
+            self.engine.close()
+            LOGGER.info("%s pose worker terminated", self.nodename)
+
+    # ------------------------------------------------------------------
+    def request_stop(self, wait_for_eos: bool) -> None:
+        self.stop_event.set()
+        if not wait_for_eos:
+            eos = Frame()
+            eos.is_eos = True
+            self.image_buffer.push(eos)
+
+    # ------------------------------------------------------------------
+    def _format_payload(self, frame: Frame, result: PoseInferenceResult) -> Dict[str, Any]:
+        detections = [
+            {
+                "bbox": detection.bbox,
+                "score": detection.score,
+                "class_id": detection.class_id,
+                "keypoints": detection.keypoints,
+            }
+            for detection in result.detections
+        ]
+        timings = {k: round(v, 3) for k, v in result.timings_ms.items()}
+        payload = {
+            "camera_index": self.camera_index,
+            "frame_index": frame.index,
+            "timestamp": frame.timestamp,
+            "monotonic_timestamp": frame.monotonic_timestamp,
+            "image_size": [frame.width, frame.height],
+            "timings_ms": timings,
+            "detections": detections,
+        }
+        return payload
+
+
+__all__ = ["PoseWorker"]

--- a/LayerSensing/Pose/tensorrt_engine.py
+++ b/LayerSensing/Pose/tensorrt_engine.py
@@ -1,0 +1,324 @@
+"""TensorRT-backed YOLOv8 pose inference utilities."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import cv2
+import numpy as np
+import torch
+
+from ultralytics.yolo.utils import ops
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PoseDetection:
+    """Single pose detection result."""
+
+    bbox: List[float]
+    score: float
+    class_id: int
+    keypoints: List[List[float]]
+
+
+@dataclass
+class PoseInferenceResult:
+    """Container for pose detections and runtime profiling information."""
+
+    detections: List[PoseDetection]
+    timings_ms: Dict[str, float]
+
+
+class TensorRTPoseEngine:
+    """Runs YOLOv8 pose models exported as TensorRT engines."""
+
+    def __init__(
+        self,
+        engine_path: Path | str,
+        *,
+        input_shape: Tuple[int, int, int] = (3, 640, 640),
+        conf_threshold: float = 0.25,
+        iou_threshold: float = 0.65,
+        max_det: int = 100,
+        num_keypoints: int = 17,
+        num_classes: int = 1,
+        warmup: bool = True,
+    ) -> None:
+        self.engine_path = Path(engine_path)
+        if not self.engine_path.is_file():
+            raise FileNotFoundError(f"TensorRT engine not found: {self.engine_path}")
+
+        self.input_shape = input_shape
+        self.conf_threshold = conf_threshold
+        self.iou_threshold = iou_threshold
+        self.max_det = max_det
+        self.num_keypoints = num_keypoints
+        self.num_classes = num_classes
+
+        self._trt, self._cudart = self._import_runtime()
+        self._runtime = self._trt.Runtime(self._trt.Logger(self._trt.Logger.WARNING))
+        with self.engine_path.open("rb") as engine_file:
+            self._engine = self._runtime.deserialize_cuda_engine(engine_file.read())
+        if self._engine is None:
+            raise RuntimeError(f"Failed to load TensorRT engine: {self.engine_path}")
+
+        self._context = self._engine.create_execution_context()
+        if self._context is None:
+            raise RuntimeError("Failed to create TensorRT execution context")
+
+        _, self._stream = self._cudart.cudaStreamCreate()
+        self._device_mem: Dict[int, int] = {}
+        self._host_mem: Dict[int, np.ndarray] = {}
+        self._host_shape: Dict[int, Tuple[int, ...]] = {}
+
+        self._input_index = self._engine.get_binding_index(self._engine[0])
+        self._output_indices = [
+            self._engine.get_binding_index(name)
+            for name in self._engine if not self._engine.binding_is_input(name)
+        ]
+        if len(self._output_indices) != 1:
+            raise RuntimeError(
+                "Pose engine is expected to expose exactly one output tensor; "
+                f"got {len(self._output_indices)} bindings."
+            )
+        self._output_index = self._output_indices[0]
+
+        self._input_dtype = np.dtype(self._trt.nptype(self._engine.get_binding_dtype(self._input_index)))
+        self._output_dtype = np.dtype(self._trt.nptype(self._engine.get_binding_dtype(self._output_index)))
+
+        if warmup:
+            LOGGER.debug("Running TensorRT pose warmup inference")
+            dummy = np.zeros((1, *self.input_shape), dtype=self._input_dtype)
+            self._run_inference(dummy)
+
+    # ---------------------------------------------------------------------
+    @staticmethod
+    def _import_runtime():
+        try:
+            import tensorrt as trt  # type: ignore
+        except ImportError as exc:  # pragma: no cover - hardware dependency
+            raise RuntimeError(
+                "TensorRT Python bindings are required to use the quantized pose engine. "
+                "Install them via `pip install --index-url https://pypi.ngc.nvidia.com nvidia-tensorrt`."
+            ) from exc
+
+        try:
+            from cuda import cudart  # type: ignore
+        except ImportError as exc:  # pragma: no cover - hardware dependency
+            raise RuntimeError(
+                "cuda-python is required for TensorRT execution. Install it with `pip install cuda-python`."
+            ) from exc
+
+        return trt, cudart
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        for ptr in self._device_mem.values():  # pragma: no cover - hardware dependency
+            self._cudart.cudaFree(ptr)
+        self._device_mem.clear()
+        self._host_mem.clear()
+        self._host_shape.clear()
+        if getattr(self, "_stream", None) is not None:
+            self._cudart.cudaStreamDestroy(self._stream)
+            self._stream = None
+        self._context = None
+        self._engine = None
+        self._runtime = None
+
+    # ------------------------------------------------------------------
+    def __del__(self):  # pragma: no cover - defensive cleanup
+        try:
+            self.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    # ------------------------------------------------------------------
+    def predict(self, image: np.ndarray) -> PoseInferenceResult:
+        """Run pose estimation on a single image."""
+        prep_start = time.perf_counter()
+        input_tensor, meta = self._preprocess(image)
+        preprocess_ms = (time.perf_counter() - prep_start) * 1000.0
+
+        infer_start = time.perf_counter()
+        raw_output = self._run_inference(input_tensor)
+        inference_ms = (time.perf_counter() - infer_start) * 1000.0
+
+        post_start = time.perf_counter()
+        detections = self._postprocess(raw_output, meta)
+        postprocess_ms = (time.perf_counter() - post_start) * 1000.0
+
+        timings = {
+            "preprocess_ms": preprocess_ms,
+            "inference_ms": inference_ms,
+            "postprocess_ms": postprocess_ms,
+        }
+        return PoseInferenceResult(detections=detections, timings_ms=timings)
+
+    # ------------------------------------------------------------------
+    def _preprocess(self, image: np.ndarray) -> Tuple[np.ndarray, Dict[str, float]]:
+        if image.ndim != 3 or image.shape[2] != 3:
+            raise ValueError("Pose engine expects color images in HxWx3 format")
+
+        h, w = image.shape[:2]
+        target_h, target_w = self.input_shape[1:]
+        if h == 0 or w == 0:
+            raise ValueError("Empty image provided to pose engine")
+
+        image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        resized, scale, (pad_x, pad_y) = self._letterbox(image_rgb, (target_h, target_w))
+        tensor = resized.astype(self._input_dtype)
+        if self._input_dtype in (np.float16, np.float32):
+            tensor = tensor / np.array(255.0, dtype=self._input_dtype)
+        tensor = np.ascontiguousarray(tensor.transpose(2, 0, 1)[None, ...])
+        return tensor, {
+            "scale": scale,
+            "pad_x": pad_x,
+            "pad_y": pad_y,
+            "orig_h": float(h),
+            "orig_w": float(w),
+        }
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _letterbox(
+        image: np.ndarray,
+        new_shape: Tuple[int, int],
+        color: Tuple[int, int, int] = (114, 114, 114),
+    ) -> Tuple[np.ndarray, float, Tuple[float, float]]:
+        shape = image.shape[:2]  # h, w
+        if not shape[0] or not shape[1]:
+            raise ValueError("Invalid image shape for letterbox")
+
+        r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+        new_unpad = (int(round(shape[1] * r)), int(round(shape[0] * r)))
+        dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]
+        dw /= 2
+        dh /= 2
+
+        resized = cv2.resize(image, new_unpad, interpolation=cv2.INTER_LINEAR)
+        top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
+        left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
+        padded = cv2.copyMakeBorder(resized, top, bottom, left, right, cv2.BORDER_CONSTANT, value=color)
+        return padded, r, (left, top)
+
+    # ------------------------------------------------------------------
+    def _ensure_allocation(self, index: int, shape: Iterable[int], dtype: np.dtype) -> None:
+        shape_tuple = tuple(int(dim) for dim in shape)
+        size = int(np.prod(shape_tuple))
+        if index in self._host_mem and self._host_mem[index].size == size:
+            return
+
+        if index in self._device_mem:
+            self._cudart.cudaFree(self._device_mem[index])
+
+        nbytes = size * dtype.itemsize
+        _, device_ptr = self._cudart.cudaMalloc(nbytes)
+        self._device_mem[index] = device_ptr
+        self._host_mem[index] = np.empty(size, dtype=dtype)
+        self._host_shape[index] = shape_tuple
+
+    # ------------------------------------------------------------------
+    def _run_inference(self, input_tensor: np.ndarray) -> np.ndarray:
+        batch_shape = tuple(input_tensor.shape)
+        self._context.set_binding_shape(self._input_index, batch_shape)
+        self._ensure_allocation(self._input_index, batch_shape, self._input_dtype)
+
+        np.copyto(self._host_mem[self._input_index].reshape(batch_shape), input_tensor)
+        self._cudart.cudaMemcpy(
+            self._device_mem[self._input_index],
+            self._host_mem[self._input_index].ctypes.data,
+            self._host_mem[self._input_index].nbytes,
+            self._cudart.cudaMemcpyKind.cudaMemcpyHostToDevice,
+        )
+
+        output_shape = self._context.get_binding_shape(self._output_index)
+        if not output_shape:
+            output_shape = self._engine.get_binding_shape(self._output_index)
+        self._ensure_allocation(self._output_index, output_shape, self._output_dtype)
+
+        bindings = [0] * self._engine.num_bindings
+        for name in self._engine:
+            idx = self._engine.get_binding_index(name)
+            bindings[idx] = self._device_mem[idx]
+
+        self._context.execute_async_v2(bindings=bindings, stream_handle=self._stream)
+        self._cudart.cudaMemcpy(
+            self._host_mem[self._output_index].ctypes.data,
+            self._device_mem[self._output_index],
+            self._host_mem[self._output_index].nbytes,
+            self._cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost,
+        )
+        self._cudart.cudaStreamSynchronize(self._stream)
+
+        return self._host_mem[self._output_index].reshape(self._host_shape[self._output_index])
+
+    # ------------------------------------------------------------------
+    def _postprocess(self, raw_output: np.ndarray, meta: Dict[str, float]) -> List[PoseDetection]:
+        if raw_output.ndim == 2:
+            pred = torch.from_numpy(raw_output[None, ...])
+        elif raw_output.ndim == 3:
+            pred = torch.from_numpy(raw_output)
+        else:
+            raise ValueError(f"Unexpected output shape from TensorRT engine: {raw_output.shape}")
+
+        if pred.shape[1] < pred.shape[2]:
+            pred = pred.permute(0, 2, 1)
+        pred = pred.float()
+
+        preds = ops.non_max_suppression(
+            pred,
+            conf_thres=self.conf_threshold,
+            iou_thres=self.iou_threshold,
+            max_det=self.max_det,
+            nc=self.num_classes,
+            nkpt=self.num_keypoints,
+            kpt_label=True,
+            multi_label=False,
+            agnostic=False,
+        )
+
+        detections: List[PoseDetection] = []
+        det = preds[0]
+        if det is None or not len(det):
+            return detections
+
+        gain = meta["scale"]
+        pad_x = meta["pad_x"]
+        pad_y = meta["pad_y"]
+        orig_h = meta["orig_h"]
+        orig_w = meta["orig_w"]
+
+        det = det.cpu().numpy()
+        boxes = det[:, :4]
+        scores = det[:, 4]
+        classes = det[:, 5].astype(int, copy=False)
+        kpt_array = det[:, 6:].reshape(-1, self.num_keypoints, 3)
+
+        boxes[:, [0, 2]] = (boxes[:, [0, 2]] - pad_x) / gain
+        boxes[:, [1, 3]] = (boxes[:, [1, 3]] - pad_y) / gain
+        boxes[:, [0, 2]] = boxes[:, [0, 2]].clip(0, orig_w - 1)
+        boxes[:, [1, 3]] = boxes[:, [1, 3]].clip(0, orig_h - 1)
+
+        kpt_array[..., 0] = (kpt_array[..., 0] - pad_x) / gain
+        kpt_array[..., 1] = (kpt_array[..., 1] - pad_y) / gain
+        kpt_array[..., 0] = kpt_array[..., 0].clip(0, orig_w - 1)
+        kpt_array[..., 1] = kpt_array[..., 1].clip(0, orig_h - 1)
+
+        for box, score, class_id, keypoints in zip(boxes, scores, classes, kpt_array):
+            detections.append(
+                PoseDetection(
+                    bbox=[float(x) for x in box.tolist()],
+                    score=float(score),
+                    class_id=int(class_id),
+                    keypoints=[[float(v) for v in kp.tolist()] for kp in keypoints],
+                )
+            )
+        return detections
+
+
+__all__ = ["TensorRTPoseEngine", "PoseDetection", "PoseInferenceResult"]

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -1,0 +1,91 @@
+"""Manager for TensorRT-based pose estimation services."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+
+from LayerCamera.CameraSystemC.recorder_module import ImageBuffer
+from lib.common import ROOTDIR
+
+from LayerSensing.Pose.pose_mqtt import PoseMqtt
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PoseManager:
+    """Control lifecycle of pose inference threads."""
+
+    def __init__(
+        self,
+        device_name: str,
+        data_handler,
+        mqtt_client: mqtt.Client,
+        imgbuf: ImageBuffer,
+    ) -> None:
+        self.device_name = device_name
+        self.data_handler = data_handler
+        self.mqtt_client = mqtt_client
+        self.image_buffer = imgbuf
+        self.pose_thread: Optional[PoseMqtt] = None
+
+    # ------------------------------------------------------------------
+    def startPose(
+        self,
+        engine_filename: str,
+        cam_idx: int,
+        *,
+        input_size: int = 640,
+        conf_threshold: float = 0.25,
+        iou_threshold: float = 0.65,
+        max_det: int = 100,
+    ):
+        try:
+            if self.pose_thread is not None:
+                raise RuntimeError("Pose worker is already running")
+
+            engine_path = Path(engine_filename)
+            if not engine_path.is_absolute():
+                engine_path = Path(ROOTDIR) / "LayerSensing" / "Pose" / "engine" / engine_filename
+            engine_path = engine_path.resolve()
+
+            self.pose_thread = PoseMqtt(
+                f"Pose_{cam_idx}",
+                self.mqtt_client,
+                self.data_handler,
+                self.image_buffer,
+                str(engine_path),
+                camera_index=cam_idx,
+                input_size=input_size,
+                conf_threshold=conf_threshold,
+                iou_threshold=iou_threshold,
+                max_det=max_det,
+            )
+            self.pose_thread.start()
+            LOGGER.info("Pose worker started for camera %s using %s", cam_idx, engine_path)
+            return {"status": "ready"}
+        except Exception as exc:
+            LOGGER.exception("Unable to start pose worker: %s", exc)
+            self.pose_thread = None
+            return {"status": "failure", "message": str(exc)}
+
+    # ------------------------------------------------------------------
+    def stopPose(self, wait_for_eos: bool = True):
+        try:
+            if self.pose_thread is None:
+                raise RuntimeError("Pose worker is not running")
+
+            self.pose_thread.request_stop(wait_for_eos)
+            self.pose_thread.join()
+            self.pose_thread = None
+            LOGGER.info("Pose worker stopped")
+            suffix = "(EOS reached)" if wait_for_eos else "(Force stop)"
+            return {"status": f"stopped {suffix}"}
+        except Exception as exc:
+            LOGGER.exception("Unable to stop pose worker: %s", exc)
+            return {"status": "failure", "message": str(exc)}
+
+
+__all__ = ["PoseManager"]

--- a/LayerSensing/SensingAgent.py
+++ b/LayerSensing/SensingAgent.py
@@ -3,6 +3,7 @@ import paho.mqtt.client as mqtt
 from lib.MqttAgent import MqttAgent
 
 from LayerCamera.CameraSystemC.recorder_module import ImageBuffer
+from LayerSensing.PoseManager import PoseManager
 from LayerSensing.TrackNetManager import TrackNetManager
 
 class SensingLayerAgent(MqttAgent):
@@ -10,6 +11,7 @@ class SensingLayerAgent(MqttAgent):
         super().__init__(device_name, "SensingLayer")
 
         self.tracknetManager = TrackNetManager(device_name, self.data_handler, self.mqttc, imgbuf)
+        self.poseManager = PoseManager(device_name, self.data_handler, self.mqttc, imgbuf)
 
     def on_connect(self, client:mqtt.Client, userdata, flags, reason_code, properties):
         super().on_connect(client, userdata, flags, reason_code, properties)
@@ -17,9 +19,12 @@ class SensingLayerAgent(MqttAgent):
         # 註冊 Sensing Layer 所提供的服務、格式化MQTT Topic(可設定suffix，預設使用function name)
         # 填入的這個function應該要有return，回傳 簡短的單次答案 / API開啟狀態(Status Code, Error Msg).etc
         self.control_handler.register_function(self.tracknetManager.startTrackNet, "TrackNet/start")
-        self.control_handler.register_function(self.tracknetManager.stopTrackNet, "TrackNet/stop")    
+        self.control_handler.register_function(self.tracknetManager.stopTrackNet, "TrackNet/stop")
         self.control_handler.register_function(self.tracknetManager.startDatafeeder, "TrackNet/startDatafeeder")
         self.control_handler.register_function(self.tracknetManager.stopDatafeeder, "TrackNet/stopDatafeeder")
+        self.control_handler.register_function(self.poseManager.startPose, "Pose/start")
+        self.control_handler.register_function(self.poseManager.stopPose, "Pose/stop")
 
         # 註冊 Sensing Layer 所發布的資料流的Topic，未來可以透過較短的稱呼(第一個參數)索引到Topic的全稱
         self.data_handler.register_topic("tracknet", "TrackNet")
+        self.data_handler.register_topic("pose", "Pose")

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ tensorboard
 torch
 torchvision
 torchaudio
+cuda-python
 scikit-video
 llvmlite
 opencv-python==4.2.0.34


### PR DESCRIPTION
## Summary
- add a TensorRT-backed pose inference engine along with worker and MQTT wrapper threads for quantized YOLOv8 pose models
- extend the sensing agent with a pose manager and topic registration to expose pose start/stop controls
- update the CUDA development Docker image and Python requirements to include cuda-python and NVIDIA TensorRT runtime support

## Testing
- python -m compileall LayerSensing/Pose LayerSensing/PoseManager.py

------
https://chatgpt.com/codex/tasks/task_e_6900802250ac8323bfc268594aca2d5f