### PR TITLE
Refactor image buffer to share frames between consumers

### DIFF
--- a/LayerCamera/CameraSystemC/common.cpp
+++ b/LayerCamera/CameraSystemC/common.cpp
@@ -1,23 +1,54 @@
 
 #include "common.h"
+#include <stdexcept>
 
 using namespace gsttcam;
 
+ImageBuffer::ImageBuffer() : _slots(MAX_SIZE) {
+    for (size_t i = 0; i < MAX_SIZE; ++i) {
+        _free_slots.push(i);
+    }
+}
+
 std::shared_ptr<Frame> ImageBuffer::pop(bool blocking)
 {
-    std::unique_lock<std::mutex> lock(_mutex);
-
-    // wait until queue is not empty
-    if (blocking) {
-        _cond.wait(lock, [this](){ return !_image_queue.empty(); });
+    size_t consumer_id;
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (!_legacy_consumer_id.has_value()) {
+            size_t id = _consumer_queues.size();
+            _consumer_queues.emplace_back();
+            _consumer_names.push_back("legacy");
+            _legacy_consumer_id = id;
+        }
+        consumer_id = _legacy_consumer_id.value();
     }
-    else if (_image_queue.empty()) {
+
+    auto handle = pop_handle(consumer_id, blocking);
+    if (!handle) {
+        return nullptr;
+    }
+    auto frame = get(handle);
+    release(handle);
+    return frame;
+}
+
+std::shared_ptr<ImageBuffer::FrameHandle> ImageBuffer::pop_handle(size_t consumer_id, bool blocking)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (consumer_id >= _consumer_queues.size()) {
         return nullptr;
     }
 
-    std::shared_ptr<Frame> ret = _image_queue.front();
+    auto &queue = _consumer_queues[consumer_id];
+    if (blocking) {
+        _cond.wait(lock, [&queue]() { return !queue.empty(); });
+    } else if (queue.empty()) {
+        return nullptr;
+    }
 
-    _image_queue.pop();
+    auto ret = queue.front();
+    queue.pop();
     return ret;
 }
 
@@ -25,20 +56,91 @@ void ImageBuffer::push(std::shared_ptr<Frame> frame)
 {
     std::unique_lock<std::mutex> lock(_mutex);
 
-    _image_queue.push(frame);
-
-    if (_image_queue.size() > MAX_SIZE) {
-        std::cerr << "ImageQueue dropped 1 frame." << std::endl;
-        _image_queue.pop();
+    const auto consumer_cnt = _consumer_queues.size();
+    if (consumer_cnt == 0) {
+        return;
     }
 
-    _cond.notify_one();
+    _cond.wait(lock, [this]() { return !_free_slots.empty(); });
+    const auto slot_idx = _free_slots.front();
+    _free_slots.pop();
+
+    FrameSlot &slot = _slots[slot_idx];
+    slot.frame = frame;
+    slot.frame_id = frame->index;
+    slot.refcnt.store(static_cast<int>(consumer_cnt));
+
+    for (auto &consumer_queue : _consumer_queues) {
+        auto handle = std::make_shared<FrameHandle>();
+        handle->slot_idx = slot_idx;
+        handle->frame_id = slot.frame_id;
+        consumer_queue.push(handle);
+    }
+
+    _cond.notify_all();
 }
+
+std::shared_ptr<Frame> ImageBuffer::get(std::shared_ptr<FrameHandle> handle)
+{
+    if (!handle) {
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (handle->slot_idx >= _slots.size()) {
+        return nullptr;
+    }
+    return _slots[handle->slot_idx].frame;
+}
+
+void ImageBuffer::release(std::shared_ptr<FrameHandle> handle)
+{
+    if (!handle) {
+        return;
+    }
+
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (handle->slot_idx >= _slots.size()) {
+        return;
+    }
+
+    FrameSlot &slot = _slots[handle->slot_idx];
+    int ref = --slot.refcnt;
+    if (ref == 0) {
+        slot.frame.reset();
+        _free_slots.push(handle->slot_idx);
+        _cond.notify_all();
+    }
+}
+
+size_t ImageBuffer::register_consumer(const std::string& name)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    size_t id = _consumer_queues.size();
+    _consumer_queues.emplace_back();
+    _consumer_names.push_back(name);
+    return id;
+}
+
 void ImageBuffer::clear()
 {
-    std::queue<std::shared_ptr<Frame>> empty_queue;
+    std::lock_guard<std::mutex> lock(_mutex);
 
-    _image_queue.swap(empty_queue);
+    _consumer_queues.clear();
+    _consumer_names.clear();
+    std::queue<size_t> empty_slots;
+    std::swap(_free_slots, empty_slots);
+    for (size_t i = 0; i < MAX_SIZE; ++i) {
+        _free_slots.push(i);
+    }
+
+    for (auto &slot : _slots) {
+        slot.frame.reset();
+        slot.refcnt.store(0);
+        slot.frame_id = 0;
+    }
+
+    _legacy_consumer_id.reset();
 }
 
 timespec get_clock_time(clockid_t clock_type) {

--- a/LayerCamera/CameraSystemC/common.h
+++ b/LayerCamera/CameraSystemC/common.h
@@ -4,6 +4,9 @@
 #include <queue>
 #include <mutex>
 #include <atomic>
+#include <optional>
+#include <string>
+#include <vector>
 #include <condition_variable>
 #include <opencv4/opencv2/opencv.hpp>
 
@@ -38,15 +41,35 @@ public:
 class ImageBuffer : public std::enable_shared_from_this<ImageBuffer>
 {
 public:
-    ImageBuffer() {};
+    ImageBuffer();
     ~ImageBuffer() {};
+    struct FrameHandle {
+        size_t slot_idx = 0;
+        uint64_t frame_id = 0;
+    };
+
+    struct FrameSlot {
+        std::shared_ptr<Frame> frame = nullptr;
+        uint64_t frame_id = 0;
+        std::atomic<int> refcnt = 0;
+    };
+
     std::shared_ptr<Frame> pop(bool blocking = true);
     void push(std::shared_ptr<Frame> frame);
     void clear();
 
+    size_t register_consumer(const std::string& name);
+    std::shared_ptr<FrameHandle> pop_handle(size_t consumer_id, bool blocking = true);
+    std::shared_ptr<Frame> get(std::shared_ptr<FrameHandle> handle);
+    void release(std::shared_ptr<FrameHandle> handle);
+
 private:
     unsigned int MAX_SIZE = 600; // 5s under 120fps
-    std::queue<std::shared_ptr<Frame>> _image_queue;
+    std::vector<FrameSlot> _slots;
+    std::queue<size_t> _free_slots;
+    std::vector<std::queue<std::shared_ptr<FrameHandle>>> _consumer_queues;
+    std::vector<std::string> _consumer_names;
+    std::optional<size_t> _legacy_consumer_id;
     std::mutex _mutex;
 
     // Condition variable for signaling

--- a/LayerCamera/CameraSystemC/recorder.cpp
+++ b/LayerCamera/CameraSystemC/recorder.cpp
@@ -486,6 +486,10 @@ PYBIND11_MODULE(recorder_module, m) {
                                                     std::vector<size_t> {f.width * sizeof(uint8_t), sizeof(uint8_t)} // stride
                                                   ));
       }, "numpy.ndarray of BGR image");
+  py::class_<gsttcam::ImageBuffer::FrameHandle, std::shared_ptr<gsttcam::ImageBuffer::FrameHandle>>(m, "FrameHandle")
+      .def(py::init<>())
+      .def_readonly("slot_idx", &gsttcam::ImageBuffer::FrameHandle::slot_idx)
+      .def_readonly("frame_id", &gsttcam::ImageBuffer::FrameHandle::frame_id);
   py::class_<gsttcam::ImageBuffer, std::shared_ptr<gsttcam::ImageBuffer>>(m, "ImageBuffer")
       .def(py::init<>())
       .def(
@@ -495,6 +499,16 @@ PYBIND11_MODULE(recorder_module, m) {
             return imgbuf.pop(blocking);
           },
           "", "blocking"_a = true)
+      .def(
+          "pop_handle",
+          [](gsttcam::ImageBuffer& imgbuf, size_t consumer_id, bool blocking = true) {
+            py::gil_scoped_release release;
+            return imgbuf.pop_handle(consumer_id, blocking);
+          },
+          "consumer_id"_a, "blocking"_a = true)
+      .def("get", &gsttcam::ImageBuffer::get)
+      .def("release", &gsttcam::ImageBuffer::release)
+      .def("register_consumer", &gsttcam::ImageBuffer::register_consumer, "name"_a)
       .def("push", &gsttcam::ImageBuffer::push)
       .def("clear", &gsttcam::ImageBuffer::clear);
 

--- a/LayerCamera/CameraSystemC/recorder_module.pyi
+++ b/LayerCamera/CameraSystemC/recorder_module.pyi
@@ -17,15 +17,27 @@ class Frame:
     @property
     def width(self) -> int: ...
 
+class FrameHandle:
+    slot_idx: int
+    frame_id: int
+
 class ImageBuffer:
     def __init__(self) -> None:
         """__init__(self: recorder_module.ImageBuffer) -> None"""
     def clear(self) -> None:
         """clear(self: recorder_module.ImageBuffer) -> None"""
+    def get(self, handle: FrameHandle) -> Frame:
+        """get(self: recorder_module.ImageBuffer, handle: recorder_module.FrameHandle) -> recorder_module.Frame"""
     def pop(self, blocking: bool = ...) -> Frame:
         """pop(self: recorder_module.ImageBuffer, blocking: bool = True) -> recorder_module.Frame"""
+    def pop_handle(self, consumer_id: int, blocking: bool = ...) -> FrameHandle:
+        """pop_handle(self: recorder_module.ImageBuffer, consumer_id: int, blocking: bool = True) -> recorder_module.FrameHandle"""
     def push(self, arg0: Frame) -> None:
         """push(self: recorder_module.ImageBuffer, arg0: recorder_module.Frame) -> None"""
+    def register_consumer(self, name: str) -> int:
+        """register_consumer(self: recorder_module.ImageBuffer, name: str) -> int"""
+    def release(self, handle: FrameHandle) -> None:
+        """release(self: recorder_module.ImageBuffer, handle: recorder_module.FrameHandle) -> None"""
 
 class MetricData:
     def __init__(self, *args, **kwargs) -> None:

--- a/LayerSensing/Pose/pose_worker.py
+++ b/LayerSensing/Pose/pose_worker.py
@@ -41,7 +41,12 @@ class PoseWorker(threading.Thread):
         self.target_fps = target_fps
         self.frame_stride = max(1, round(base_camera_fps / target_fps)) if target_fps > 0 else 1
         self.effective_fps = base_camera_fps / self.frame_stride
-        self.consumer_id = self.image_buffer.register_consumer(f"{nodename}_pose")
+        self._use_handles = hasattr(self.image_buffer, "register_consumer")
+        self.consumer_id = (
+            self.image_buffer.register_consumer(f"{nodename}_pose")
+            if self._use_handles
+            else None
+        )
 
         self.engine = TensorRTPoseEngine(
             engine_path,
@@ -62,12 +67,17 @@ class PoseWorker(threading.Thread):
         )
         try:
             while not self.stop_event.is_set():
-                handle = self.image_buffer.pop_handle(self.consumer_id, True)
-                if handle is None:
-                    continue
-                frame = self.image_buffer.get(handle)
+                handle = None
+                if self._use_handles:
+                    handle = self.image_buffer.pop_handle(self.consumer_id, True)
+                    if handle is None:
+                        continue
+                    frame = self.image_buffer.get(handle)
+                else:
+                    frame = self.image_buffer.pop(True)
                 if frame is None:
-                    self.image_buffer.release(handle)
+                    if handle is not None:
+                        self.image_buffer.release(handle)
                     continue
                 try:
                     if frame.is_eos:
@@ -82,7 +92,8 @@ class PoseWorker(threading.Thread):
                     except Exception as exc:  # pragma: no cover - defensive logging
                         LOGGER.exception("Pose inference failed: %s", exc)
                 finally:
-                    self.image_buffer.release(handle)
+                    if handle is not None:
+                        self.image_buffer.release(handle)
         finally:
             self.engine.close()
             LOGGER.info("%s pose worker terminated", self.nodename)

--- a/LayerSensing/Pose/pose_worker.py
+++ b/LayerSensing/Pose/pose_worker.py
@@ -41,6 +41,7 @@ class PoseWorker(threading.Thread):
         self.target_fps = target_fps
         self.frame_stride = max(1, round(base_camera_fps / target_fps)) if target_fps > 0 else 1
         self.effective_fps = base_camera_fps / self.frame_stride
+        self.consumer_id = self.image_buffer.register_consumer(f"{nodename}_pose")
 
         self.engine = TensorRTPoseEngine(
             engine_path,
@@ -61,20 +62,27 @@ class PoseWorker(threading.Thread):
         )
         try:
             while not self.stop_event.is_set():
-                frame = self.image_buffer.pop(True)
-                if frame is None:
+                handle = self.image_buffer.pop_handle(self.consumer_id, True)
+                if handle is None:
                     continue
-                if frame.is_eos:
-                    LOGGER.info("%s pose worker received EOS", self.nodename)
-                    break
-                if frame.index % self.frame_stride != 0:
+                frame = self.image_buffer.get(handle)
+                if frame is None:
+                    self.image_buffer.release(handle)
                     continue
                 try:
-                    result = self.engine.predict(frame.image)
-                    payload = self._format_payload(frame, result)
-                    self.data_handler.publish("pose", json.dumps(payload))
-                except Exception as exc:  # pragma: no cover - defensive logging
-                    LOGGER.exception("Pose inference failed: %s", exc)
+                    if frame.is_eos:
+                        LOGGER.info("%s pose worker received EOS", self.nodename)
+                        break
+                    if frame.index % self.frame_stride != 0:
+                        continue
+                    try:
+                        result = self.engine.predict(frame.image)
+                        payload = self._format_payload(frame, result)
+                        self.data_handler.publish("pose", json.dumps(payload))
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        LOGGER.exception("Pose inference failed: %s", exc)
+                finally:
+                    self.image_buffer.release(handle)
         finally:
             self.engine.close()
             LOGGER.info("%s pose worker terminated", self.nodename)

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferDataset.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferDataset.py
@@ -11,6 +11,7 @@ class ImageBufferDataset(Dataset):
         self.track_size = track_size
         self.buffer = []  # 儲存一組 track_size 連續 frame
         self.imgsz = 640
+        self.consumer_id = self.image_buffer.register_consumer("tracknet_dataset")
 
     def __len__(self):
         return 1_000_000  # 任意大，會由外部控制終止（如遇到 EOS）
@@ -29,14 +30,23 @@ class ImageBufferDataset(Dataset):
         # timestamps = []
 
         while len(frames) < self.track_size:
-            frame = self.image_buffer.pop(True)
-            if frame.is_eos:
-                raise StopIteration  # 結束迴圈
-            img = frame.image.astype(np.float32)
-            img = self.pad_to_square(img)
-            img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
-            img = np.expand_dims(img, axis=0)  # (1, H, W)
-            frames.append(img)
+            handle = self.image_buffer.pop_handle(self.consumer_id, True)
+            if handle is None:
+                continue
+            frame = self.image_buffer.get(handle)
+            if frame is None:
+                self.image_buffer.release(handle)
+                continue
+            try:
+                if frame.is_eos:
+                    raise StopIteration  # 結束迴圈
+                img = frame.image.astype(np.float32)
+                img = self.pad_to_square(img)
+                img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
+                img = np.expand_dims(img, axis=0)  # (1, H, W)
+                frames.append(img)
+            finally:
+                self.image_buffer.release(handle)
             # frames.append(frame.image)
             # fids.append(frame.index)
             # timestamps.append(frame.monotonic_timestamp)

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferDataset.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferDataset.py
@@ -11,7 +11,12 @@ class ImageBufferDataset(Dataset):
         self.track_size = track_size
         self.buffer = []  # 儲存一組 track_size 連續 frame
         self.imgsz = 640
-        self.consumer_id = self.image_buffer.register_consumer("tracknet_dataset")
+        self._use_handles = hasattr(self.image_buffer, "register_consumer")
+        self.consumer_id = (
+            self.image_buffer.register_consumer("tracknet_dataset")
+            if self._use_handles
+            else None
+        )
 
     def __len__(self):
         return 1_000_000  # 任意大，會由外部控制終止（如遇到 EOS）
@@ -30,12 +35,17 @@ class ImageBufferDataset(Dataset):
         # timestamps = []
 
         while len(frames) < self.track_size:
-            handle = self.image_buffer.pop_handle(self.consumer_id, True)
-            if handle is None:
-                continue
-            frame = self.image_buffer.get(handle)
+            handle = None
+            if self._use_handles:
+                handle = self.image_buffer.pop_handle(self.consumer_id, True)
+                if handle is None:
+                    continue
+                frame = self.image_buffer.get(handle)
+            else:
+                frame = self.image_buffer.pop(True)
             if frame is None:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
                 continue
             try:
                 if frame.is_eos:
@@ -46,7 +56,8 @@ class ImageBufferDataset(Dataset):
                 img = np.expand_dims(img, axis=0)  # (1, H, W)
                 frames.append(img)
             finally:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
             # frames.append(frame.image)
             # fids.append(frame.index)
             # timestamps.append(frame.monotonic_timestamp)

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
@@ -103,7 +103,12 @@ class ImageBufferPredictor:
         self.image_buffer = image_buffer
         self.track_size = 10
         self.imgsz = 640
-        self.consumer_id = self.image_buffer.register_consumer("tracknet_predictor")
+        self._use_handles = hasattr(self.image_buffer, "register_consumer")
+        self.consumer_id = (
+            self.image_buffer.register_consumer("tracknet_predictor")
+            if self._use_handles
+            else None
+        )
 
         self.max_streams = torch.cuda.device_count() * 2
         self.streams = [torch.cuda.Stream(device=self.device) for _ in range(self.max_streams)]
@@ -154,12 +159,17 @@ class ImageBufferPredictor:
     def _preprocess(self) -> Tuple[torch.Tensor, List[int], List[float]]:
         frames, fids, timestamps = [], [], []
         while len(frames) < self.track_size:
-            handle = self.image_buffer.pop_handle(self.consumer_id, True)
-            if handle is None:
-                continue
-            frame = self.image_buffer.get(handle)
+            handle = None
+            if self._use_handles:
+                handle = self.image_buffer.pop_handle(self.consumer_id, True)
+                if handle is None:
+                    continue
+                frame = self.image_buffer.get(handle)
+            else:
+                frame = self.image_buffer.pop(True)
             if frame is None:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
                 continue
             try:
                 if frame.is_eos:
@@ -181,7 +191,8 @@ class ImageBufferPredictor:
                 fids.append(frame.index)
                 timestamps.append(frame.monotonic_timestamp)
             finally:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
 
         if len(frames) < self.track_size:
             for _ in range(self.track_size - len(frames)):

--- a/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
+++ b/LayerSensing/TrackNet/Tracknet1000/ImageBufferPredictor.py
@@ -103,6 +103,7 @@ class ImageBufferPredictor:
         self.image_buffer = image_buffer
         self.track_size = 10
         self.imgsz = 640
+        self.consumer_id = self.image_buffer.register_consumer("tracknet_predictor")
 
         self.max_streams = torch.cuda.device_count() * 2
         self.streams = [torch.cuda.Stream(device=self.device) for _ in range(self.max_streams)]
@@ -153,25 +154,34 @@ class ImageBufferPredictor:
     def _preprocess(self) -> Tuple[torch.Tensor, List[int], List[float]]:
         frames, fids, timestamps = [], [], []
         while len(frames) < self.track_size:
-            frame = self.image_buffer.pop(True)
-            if frame.is_eos:
-                self.stop()
-                self.data_handler.publish("tracknet", json.dumps({"linear": [], "EOF": True}))
-                break
+            handle = self.image_buffer.pop_handle(self.consumer_id, True)
+            if handle is None:
+                continue
+            frame = self.image_buffer.get(handle)
+            if frame is None:
+                self.image_buffer.release(handle)
+                continue
+            try:
+                if frame.is_eos:
+                    self.stop()
+                    self.data_handler.publish("tracknet", json.dumps({"linear": [], "EOF": True}))
+                    break
 
-            # 目前傳入的尺寸不精確，在此額外處理
-            self.output_height, self.output_width = frame.image.shape[:2]
+                # 目前傳入的尺寸不精確，在此額外處理
+                self.output_height, self.output_width = frame.image.shape[:2]
 
-            if self.save_pred_images:
-                self._frame_cache[frame.index] = frame.image.copy()
-            img = frame.image.astype(np.float32)
-            if img.ndim == 3:
-                img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-            img = self.pad_to_square(img)
-            img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
-            frames.append(np.expand_dims(img, axis=0))
-            fids.append(frame.index)
-            timestamps.append(frame.monotonic_timestamp)
+                if self.save_pred_images:
+                    self._frame_cache[frame.index] = frame.image.copy()
+                img = frame.image.astype(np.float32)
+                if img.ndim == 3:
+                    img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+                img = self.pad_to_square(img)
+                img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
+                frames.append(np.expand_dims(img, axis=0))
+                fids.append(frame.index)
+                timestamps.append(frame.monotonic_timestamp)
+            finally:
+                self.image_buffer.release(handle)
 
         if len(frames) < self.track_size:
             for _ in range(self.track_size - len(frames)):

--- a/ultralytics/tracknet/image_buffer_predictor.py
+++ b/ultralytics/tracknet/image_buffer_predictor.py
@@ -44,7 +44,12 @@ class ImageBufferPredictor:
         self.image_buffer = image_buffer
         self.track_size = 10
         self.imgsz = 640
-        self.consumer_id = self.image_buffer.register_consumer("tracknet_predictor")
+        self._use_handles = hasattr(self.image_buffer, "register_consumer")
+        self.consumer_id = (
+            self.image_buffer.register_consumer("tracknet_predictor")
+            if self._use_handles
+            else None
+        )
 
         self.max_streams = torch.cuda.device_count() * 2
         self.streams = [torch.cuda.Stream(device=self.device) for _ in range(self.max_streams)]
@@ -111,12 +116,17 @@ class ImageBufferPredictor:
     def _preprocess(self) -> Tuple[torch.Tensor, List[int], List[float]]:
         frames, fids, timestamps = [], [], []
         while len(frames) < self.track_size:
-            handle = self.image_buffer.pop_handle(self.consumer_id, True)
-            if handle is None:
-                continue
-            frame = self.image_buffer.get(handle)
+            handle = None
+            if self._use_handles:
+                handle = self.image_buffer.pop_handle(self.consumer_id, True)
+                if handle is None:
+                    continue
+                frame = self.image_buffer.get(handle)
+            else:
+                frame = self.image_buffer.pop(True)
             if frame is None:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
                 continue
 
             try:
@@ -132,7 +142,8 @@ class ImageBufferPredictor:
                     self.stop()
                     break
             finally:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
 
         if len(frames) < self.track_size:
             for _ in range(self.track_size - len(frames)):

--- a/ultralytics/tracknet/image_buffer_predictor.py
+++ b/ultralytics/tracknet/image_buffer_predictor.py
@@ -44,6 +44,7 @@ class ImageBufferPredictor:
         self.image_buffer = image_buffer
         self.track_size = 10
         self.imgsz = 640
+        self.consumer_id = self.image_buffer.register_consumer("tracknet_predictor")
 
         self.max_streams = torch.cuda.device_count() * 2
         self.streams = [torch.cuda.Stream(device=self.device) for _ in range(self.max_streams)]
@@ -110,19 +111,28 @@ class ImageBufferPredictor:
     def _preprocess(self) -> Tuple[torch.Tensor, List[int], List[float]]:
         frames, fids, timestamps = [], [], []
         while len(frames) < self.track_size:
-            frame = self.image_buffer.pop(True)
+            handle = self.image_buffer.pop_handle(self.consumer_id, True)
+            if handle is None:
+                continue
+            frame = self.image_buffer.get(handle)
+            if frame is None:
+                self.image_buffer.release(handle)
+                continue
 
-            img = frame.image.astype(np.float32)
-            if img.ndim == 3:
-                img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-            img = self.pad_to_square(img)
-            img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
-            frames.append(np.expand_dims(img, axis=0))
-            fids.append(frame.index)
-            timestamps.append(frame.monotonic_timestamp)
-            if frame.is_eos:
-                self.stop()
-                break
+            try:
+                img = frame.image.astype(np.float32)
+                if img.ndim == 3:
+                    img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+                img = self.pad_to_square(img)
+                img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
+                frames.append(np.expand_dims(img, axis=0))
+                fids.append(frame.index)
+                timestamps.append(frame.monotonic_timestamp)
+                if frame.is_eos:
+                    self.stop()
+                    break
+            finally:
+                self.image_buffer.release(handle)
 
         if len(frames) < self.track_size:
             for _ in range(self.track_size - len(frames)):

--- a/ultralytics/tracknet/pred_stream_dataset.py
+++ b/ultralytics/tracknet/pred_stream_dataset.py
@@ -5,16 +5,18 @@ from torch.utils.data import Dataset
 
 from ultralytics.tracknet.protocal.image_buffer import ImageBufferProtocol
 
+
 class ImageBufferDataset(Dataset):
     def __init__(self, image_buffer: ImageBufferProtocol, track_size: int = 10):
         self.image_buffer = image_buffer
         self.track_size = track_size
         self.buffer = []  # 儲存一組 track_size 連續 frame
         self.imgsz = 640
+        self.consumer_id = self.image_buffer.register_consumer("tracknet_dataset")
 
     def __len__(self):
         return 1_000_000  # 任意大，會由外部控制終止（如遇到 EOS）
-    
+
     def pad_to_square(self, img, pad_value=0):
         h, w = img.shape
         dim_diff = np.abs(h - w)
@@ -22,25 +24,34 @@ class ImageBufferDataset(Dataset):
         pad = (0, 0, pad1, pad2) if h > w else (pad1, pad2, 0, 0)
         img = cv2.copyMakeBorder(img, *pad, borderType=cv2.BORDER_CONSTANT, value=pad_value)
         return img
-    
+
     def __getitem__(self, index):
         frames = []
         fids = []
         timestamps = []
 
         while len(frames) < self.track_size:
-            frame = self.image_buffer.pop(True)
-            if frame.is_eos:
-                raise StopIteration  # 結束迴圈
-            img = frame.image.astype(np.float32)
-            img = self.pad_to_square(img)
-            img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
-            img = np.expand_dims(img, axis=0)  # (1, H, W)
-            frames.append(img)
-            fids.append(frame.index)
-            timestamps.append(frame.monotonic_timestamp)
+            handle = self.image_buffer.pop_handle(self.consumer_id, True)
+            if handle is None:
+                continue
+            frame = self.image_buffer.get(handle)
+            if frame is None:
+                self.image_buffer.release(handle)
+                continue
+            try:
+                if frame.is_eos:
+                    raise StopIteration  # 結束迴圈
+                img = frame.image.astype(np.float32)
+                img = self.pad_to_square(img)
+                img = cv2.resize(img, dsize=(self.imgsz, self.imgsz), interpolation=cv2.INTER_CUBIC)
+                img = np.expand_dims(img, axis=0)  # (1, H, W)
+                frames.append(img)
+                fids.append(frame.index)
+                timestamps.append(frame.monotonic_timestamp)
+            finally:
+                self.image_buffer.release(handle)
 
         img = np.concatenate(frames, 0)
         img_tensor = torch.from_numpy(img).float()
-            
+
         return (f"stream_dataset_{index}", img_tensor, "", "", fids, timestamps)

--- a/ultralytics/tracknet/pred_stream_dataset.py
+++ b/ultralytics/tracknet/pred_stream_dataset.py
@@ -12,7 +12,12 @@ class ImageBufferDataset(Dataset):
         self.track_size = track_size
         self.buffer = []  # 儲存一組 track_size 連續 frame
         self.imgsz = 640
-        self.consumer_id = self.image_buffer.register_consumer("tracknet_dataset")
+        self._use_handles = hasattr(self.image_buffer, "register_consumer")
+        self.consumer_id = (
+            self.image_buffer.register_consumer("tracknet_dataset")
+            if self._use_handles
+            else None
+        )
 
     def __len__(self):
         return 1_000_000  # 任意大，會由外部控制終止（如遇到 EOS）
@@ -31,12 +36,17 @@ class ImageBufferDataset(Dataset):
         timestamps = []
 
         while len(frames) < self.track_size:
-            handle = self.image_buffer.pop_handle(self.consumer_id, True)
-            if handle is None:
-                continue
-            frame = self.image_buffer.get(handle)
+            handle = None
+            if self._use_handles:
+                handle = self.image_buffer.pop_handle(self.consumer_id, True)
+                if handle is None:
+                    continue
+                frame = self.image_buffer.get(handle)
+            else:
+                frame = self.image_buffer.pop(True)
             if frame is None:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
                 continue
             try:
                 if frame.is_eos:
@@ -49,7 +59,8 @@ class ImageBufferDataset(Dataset):
                 fids.append(frame.index)
                 timestamps.append(frame.monotonic_timestamp)
             finally:
-                self.image_buffer.release(handle)
+                if handle is not None:
+                    self.image_buffer.release(handle)
 
         img = np.concatenate(frames, 0)
         img_tensor = torch.from_numpy(img).float()

--- a/ultralytics/tracknet/protocal/image_buffer.py
+++ b/ultralytics/tracknet/protocal/image_buffer.py
@@ -3,26 +3,49 @@ from typing import Protocol
 import numpy as np
 import threading
 
+
 class FrameProtocol(Protocol):
     is_eos: bool
 
     @property
     def height(self) -> int: ...
+
     @property
     def image(self) -> np.ndarray[np.uint8]: ...
+
     @property
     def index(self) -> int: ...
+
     @property
     def monotonic_timestamp(self) -> float: ...
+
     @property
     def timestamp(self) -> float: ...
+
     @property
     def width(self) -> int: ...
 
+
+class FrameHandleProtocol(Protocol):
+    slot_idx: int
+    frame_id: int
+
+
 class ImageBufferProtocol(Protocol):
     def clear(self) -> None: ...
+
+    def get(self, handle: FrameHandleProtocol) -> FrameProtocol: ...
+
     def pop(self, blocking: bool = True) -> FrameProtocol: ...
+
+    def pop_handle(self, consumer_id: int, blocking: bool = True) -> FrameHandleProtocol: ...
+
     def push(self, frame: FrameProtocol) -> None: ...
+
+    def register_consumer(self, name: str) -> int: ...
+
+    def release(self, handle: FrameHandleProtocol) -> None: ...
+
 
 class FakeFrame:
     def __init__(self, image: np.ndarray, index: int, is_eos=False):
@@ -60,23 +83,87 @@ class FakeFrame:
     def width(self) -> int:
         return self._image.shape[1]
 
+
 class FakeImageBuffer:
     def __init__(self):
-        self.queue = []
         self.lock = threading.Lock()
         self.cv = threading.Condition(self.lock)
+        self.slots: list[dict] = []
+        self.free_slots: list[int] = []
+        self.consumer_queues: list[list[dict]] = []
+        self.legacy_consumer: int | None = None
+
+    def _ensure_legacy_consumer(self) -> int:
+        if self.legacy_consumer is None:
+            self.legacy_consumer = self.register_consumer("legacy")
+        return self.legacy_consumer
 
     def push(self, frame):
         with self.cv:
-            self.queue.append(frame)
-            self.cv.notify()
+            if not self.consumer_queues:
+                return
+            if self.free_slots:
+                slot_idx = self.free_slots.pop()
+                if slot_idx < len(self.slots):
+                    self.slots[slot_idx]["frame"] = frame
+                    self.slots[slot_idx]["refcnt"] = len(self.consumer_queues)
+                else:
+                    self.slots.append({"frame": frame, "refcnt": len(self.consumer_queues)})
+            else:
+                slot_idx = len(self.slots)
+                self.slots.append({"frame": frame, "refcnt": len(self.consumer_queues)})
+            for queue in self.consumer_queues:
+                queue.append({"slot_idx": slot_idx, "frame_id": getattr(frame, "index", 0)})
+            self.cv.notify_all()
 
     def pop(self, blocking=True):
+        consumer_id = self._ensure_legacy_consumer()
+        handle = self.pop_handle(consumer_id, blocking)
+        if handle is None:
+            return None
+        frame = self.get(handle)
+        self.release(handle)
+        return frame
+
+    def pop_handle(self, consumer_id: int, blocking: bool = True):
         with self.cv:
-            while blocking and not self.queue:
+            if consumer_id >= len(self.consumer_queues):
+                return None
+            queue = self.consumer_queues[consumer_id]
+            while blocking and not queue:
                 self.cv.wait()
-            return self.queue.pop(0)
+            if not queue:
+                return None
+            return queue.pop(0)
+
+    def get(self, handle):
+        if handle is None:
+            return None
+        with self.cv:
+            if handle["slot_idx"] >= len(self.slots):
+                return None
+            return self.slots[handle["slot_idx"]]["frame"]
+
+    def release(self, handle):
+        if handle is None:
+            return
+        with self.cv:
+            slot_idx = handle["slot_idx"]
+            if slot_idx >= len(self.slots):
+                return
+            self.slots[slot_idx]["refcnt"] -= 1
+            if self.slots[slot_idx]["refcnt"] <= 0:
+                self.free_slots.append(slot_idx)
+            self.cv.notify_all()
+
+    def register_consumer(self, name: str):
+        with self.cv:
+            self.consumer_queues.append([])
+            return len(self.consumer_queues) - 1
 
     def clear(self):
         with self.cv:
-            self.queue.clear()
+            self.slots.clear()
+            self.free_slots.clear()
+            self.consumer_queues.clear()
+            self.legacy_consumer = None


### PR DESCRIPTION
## Summary
- add refcounted slot handles to the C++ ImageBuffer so multiple consumers receive the same frame without duplication
- expose handle APIs through the Python bindings and protocol stubs
- update pose and TrackNet data pipelines to register their own queues and release frames after inference

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5dd45cf883239b82cd0e22885f64)