### PR TITLE
Use sliding window for TrackNet inference

### DIFF
--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -203,10 +203,9 @@ class TrackNetMqtt(threading.Thread):
         self.model = model
 
     def run(self):
-        size = 0
-        list_images = []
-        list_fids = []
-        list_timestamps = []
+        window_images = []
+        window_fids = []
+        window_timestamps = []
 
         # TrackNet
         tracknetThread = TrackNetThread(device=self.device,
@@ -220,33 +219,32 @@ class TrackNetMqtt(threading.Thread):
 
         while not self._stopped():
 
-            while (not self._stopped()) and size < TRACK_SIZE:
-                frame = self.imageBuffer.pop(True)
-                if frame.is_eos:
-                    if self.data_handler is not None:
-                        self.data_handler.publish("tracknet", json.dumps({"linear": [], "EOF": True}))
-                    logging.info(f"{self.nodename} EOF reached.")
-                    self.stop()
-                    break
-                list_images.append(frame.image)
-                list_fids.append(frame.index)
-                list_timestamps.append(frame.monotonic_timestamp)
-                size += 1
-
-            if self._stopped():
+            frame = self.imageBuffer.pop(True)
+            if frame.is_eos:
+                if self.data_handler is not None:
+                    self.data_handler.publish("tracknet", json.dumps({"linear": [], "EOF": True}))
+                logging.info(f"{self.nodename} EOF reached.")
+                self.stop()
                 break
 
-            # run tracknet
+            window_images.append(frame.image)
+            window_fids.append(frame.index)
+            window_timestamps.append(frame.monotonic_timestamp)
+
+            if len(window_images) < TRACK_SIZE:
+                continue
+
+            # run tracknet on a sliding window to avoid skipping frames
             tracknetThread.init()
-            tracknetThread.images = list_images.copy()
-            tracknetThread.fids = list_fids.copy()
-            tracknetThread.timestamps = list_timestamps.copy()
+            tracknetThread.images = window_images.copy()
+            tracknetThread.fids = window_fids.copy()
+            tracknetThread.timestamps = window_timestamps.copy()
             tracknetThread.run()
 
-            list_images.clear()
-            list_fids.clear()
-            list_timestamps.clear()
-            size = 0
+            # slide window by one frame
+            window_images.pop(0)
+            window_fids.pop(0)
+            window_timestamps.pop(0)
         
         if self.csv_writer is not None:
             self.csv_writer.close()

--- a/LayerSensing/TrackNet/TrackNetMqtt.py
+++ b/LayerSensing/TrackNet/TrackNetMqtt.py
@@ -185,6 +185,14 @@ class TrackNetMqtt(threading.Thread):
 
         self._stopper = threading.Event()
 
+        # Image buffer consumer (if supported)
+        self._use_handles = hasattr(self.imageBuffer, "register_consumer")
+        self.consumer_id = (
+            self.imageBuffer.register_consumer(f"{nodename}_tracknet")
+            if self._use_handles
+            else None
+        )
+
     def stop(self):
         self._stopper.set()  
 
@@ -219,17 +227,29 @@ class TrackNetMqtt(threading.Thread):
 
         while not self._stopped():
 
-            frame = self.imageBuffer.pop(True)
+            handle = None
+            if self._use_handles:
+                handle = self.imageBuffer.pop_handle(self.consumer_id, True)
+                if handle is None:
+                    continue
+                frame = self.imageBuffer.get(handle)
+            else:
+                frame = self.imageBuffer.pop(True)
             if frame.is_eos:
                 if self.data_handler is not None:
                     self.data_handler.publish("tracknet", json.dumps({"linear": [], "EOF": True}))
                 logging.info(f"{self.nodename} EOF reached.")
+                if handle is not None:
+                    self.imageBuffer.release(handle)
                 self.stop()
                 break
 
             window_images.append(frame.image)
             window_fids.append(frame.index)
             window_timestamps.append(frame.monotonic_timestamp)
+
+            if handle is not None:
+                self.imageBuffer.release(handle)
 
             if len(window_images) < TRACK_SIZE:
                 continue


### PR DESCRIPTION
## Summary
- process TrackNet MQTT frames with a sliding window instead of non-overlapping batches
- keep window buffered and slide by one frame to avoid skipping detections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d818115488323a3fc91164cf2f50e)