### PR TITLE
Add batched pose inference and engine-version selection (batch1/batch3)

### DIFF
--- a/LayerApplication/Rpc/RpcStreamingBadminton.py
+++ b/LayerApplication/Rpc/RpcStreamingBadminton.py
@@ -166,13 +166,14 @@ class RpcStreamingBadminton:
 
         self._setupUnsubscribe()
 
-    def start(self, content_mode="CES", tracknet_ver="tracknet_v2", record_mode="h264_high"):
+    def start(self, content_mode="CES", tracknet_ver="tracknet_v2", record_mode="h264_high", tracknet_weight=None):
         """Start
 
         Args:
             content_mode (str, optional): Content 模式. Defaults to "CES".
             tracknet_ver (str, optional): Tracknet 版本. Available options: ["tracknet_v2", "tracknet_1000"].
             record_mode (str, optional): Camera 錄影模式. Available options: ["none", "h264_low", "h264_high"].
+            tracknet_weight (str | None, optional): Tracknet 權重檔名。若未提供則使用預設值。
         """
 
         self._verifyRequirements()
@@ -199,20 +200,25 @@ class RpcStreamingBadminton:
         # ====== Setup sensing ======
 
         camera_image_res = (512, 288)
+        weight_name = (tracknet_weight or "").strip()
 
         if tracknet_ver == "tracknet_1000":
             camera_image_res = (640, 480)
+            weight_in_use = weight_name or "best.pt"
             # Setup sensing
             for cam_idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
                 cameraAgent = self.manager.cameraLayerAgents[cam_idx]
-                ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_1000", "best.pt", replay_dirname, cam_idx)
+                ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_1000", weight_in_use, replay_dirname, cam_idx)
+                pose_ret = sensingAgent.startPose(cameraAgent.resolution, "best_int8_cu12.engine", replay_dirname=replay_dirname, cam_idx=cam_idx)
                 logging.info(f"TrackNet_{cam_idx}: {str(ret)}")
+                logging.info(f"Pose_{cam_idx}: {str(pose_ret)}")
         else:
             # tracknet_v2
             camera_image_res = (512, 288)
+            weight_in_use = weight_name or "no114_30.tar"
             for cam_idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
                 cameraAgent = self.manager.cameraLayerAgents[cam_idx]
-                ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_v2", "no114_30.tar", replay_dirname, cam_idx)
+                ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_v2", weight_in_use, replay_dirname, cam_idx)
                 logging.info(f"TrackNet_{cam_idx}: {str(ret)}")
 
         # ====== Setup camera ======

--- a/LayerApplication/UI/Debug/StreamingDemoPage.py
+++ b/LayerApplication/UI/Debug/StreamingDemoPage.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import time
 import json
+from pathlib import Path
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
@@ -20,7 +21,7 @@ from ..UISettings import *
 from ..Services import SystemService
 from lib.message import *
 
-from lib.common import ICONDIR
+from lib.common import ICONDIR, ROOTDIR
 
 class StreamingDemoPage(QGroupBox):
     signal_tracknet_0 = pyqtSignal(bytes)
@@ -111,6 +112,29 @@ class StreamingDemoPage(QGroupBox):
         self.trajectory_widget.reset()
         self.ball_point_widget.reset()
 
+    def _load_tracknet_weights(self):
+        version = self.combo_tracknet_ver.currentText()
+        base_dir = Path(ROOTDIR) / "LayerSensing" / "TrackNet"
+        if version == "tracknet_1000":
+            base_dir = base_dir / "Tracknet1000" / "weights"
+            allowed_suffixes = {".pt", ".pth"}
+            default_weight = "best.pt"
+        else:
+            base_dir = base_dir / "TrackNet10" / "weights"
+            allowed_suffixes = {".tar", ".pt", ".pth"}
+            default_weight = "no114_30.tar"
+
+        weights = []
+        if base_dir.exists():
+            weights = [p.name for p in sorted(base_dir.iterdir()) if p.is_file() and p.suffix.lower() in allowed_suffixes]
+
+        if not weights and default_weight:
+            weights.append(default_weight)
+
+        self.combo_tracknet_weight.clear()
+        self.combo_tracknet_weight.addItems(weights)
+        self.combo_tracknet_weight.setEnabled(bool(weights))
+
     def startTest(self):
         self._clearOutput()
         self.ball_point_widget.reset()
@@ -138,8 +162,9 @@ class StreamingDemoPage(QGroupBox):
             content_mode = self.combo_mode.currentText()
             record_mode = self.combo_record_mode.currentText()
             tracknet_ver = self.combo_tracknet_ver.currentText()
+            tracknet_weight = self.combo_tracknet_weight.currentText().strip() if self.combo_tracknet_weight.count() else ""
 
-            self.rpcStreamingBadminton.start(content_mode=content_mode, tracknet_ver=tracknet_ver, record_mode=record_mode)
+            self.rpcStreamingBadminton.start(content_mode=content_mode, tracknet_ver=tracknet_ver, record_mode=record_mode, tracknet_weight=tracknet_weight)
             self.btn_run.setText(f"Stop")
         else:
             self.rpcStreamingBadminton.stop()
@@ -356,8 +381,15 @@ class StreamingDemoPage(QGroupBox):
         self.combo_tracknet_ver = QComboBox()
         self.combo_tracknet_ver.addItems(["tracknet_v2", "tracknet_1000"])
         self.combo_tracknet_ver.setCurrentText("tracknet_v2")
+        self.combo_tracknet_ver.currentTextChanged.connect(self._load_tracknet_weights)
         tracknet_ver_layout.addWidget(label_tracknet_ver, stretch=1)
         tracknet_ver_layout.addWidget(self.combo_tracknet_ver, stretch=2)
+
+        tracknet_weight_layout = QHBoxLayout()
+        label_tracknet_weight = QLabel("TrackNet Weight:")
+        self.combo_tracknet_weight = QComboBox()
+        tracknet_weight_layout.addWidget(label_tracknet_weight, stretch=1)
+        tracknet_weight_layout.addWidget(self.combo_tracknet_weight, stretch=2)
 
         self.btn_run = QPushButton()
         self.btn_run.setText('Run')
@@ -375,9 +407,12 @@ class StreamingDemoPage(QGroupBox):
         container_layout.addWidget(self.btn_home)
         container_layout.addLayout(mode_layout)
         container_layout.addLayout(tracknet_ver_layout)
+        container_layout.addLayout(tracknet_weight_layout)
         container_layout.addLayout(record_mode_layout)
         container_layout.addWidget(self.btn_run)
         container_layout.addWidget(self.btn_debug_run)
         container.setLayout(container_layout)
+
+        self._load_tracknet_weights()
 
         return container

--- a/LayerSensing/Pose/PoseEngine.py
+++ b/LayerSensing/Pose/PoseEngine.py
@@ -12,13 +12,22 @@ class PoseDetection:
     bbox_conf: float
     keypoints: list
 
-
 class TensorRTPoseEngine:
-    def __init__(self, engine_path: str, input_size=(640, 640), conf_thres: float = 0.25, kpt_thres: float = 0.1):
+    def __init__(
+        self,
+        engine_path: str,
+        input_size=(640, 640),
+        conf_thres: float = 0.6,
+        kpt_thres: float = 0.1,
+        iou_thres: float = 0.45,
+        max_det: int = 2,
+    ):
         self.engine_path = engine_path
         self.input_size = input_size
         self.conf_thres = conf_thres
         self.kpt_thres = kpt_thres
+        self.iou_thres = iou_thres
+        self.max_det = max_det
         self.runtime = None
         self.engine = None
         self.context = None
@@ -69,7 +78,7 @@ class TensorRTPoseEngine:
     def infer(self, image: np.ndarray) -> List[PoseDetection]:
         batch_result = self.infer_batch([image])
         return batch_result[0] if batch_result else []
-
+    
     def infer_batch(self, images: List[np.ndarray]) -> List[List[PoseDetection]]:
         if not self._load_ok:
             return [[] for _ in images]
@@ -210,11 +219,9 @@ class TensorRTPoseEngine:
         if raw.ndim == 1:
             raw = raw.reshape(1, -1)
 
-        # common layout from YOLO-based TRT export: [C, N]
         if raw.ndim == 2 and raw.shape[0] in (56, 57) and raw.shape[1] > raw.shape[0]:
             raw = raw.T
 
-        # convert 56-col format [cx,cy,w,h,conf,kpts(51)] to existing 57-col parser format
         if raw.ndim == 2 and raw.shape[1] == 56:
             zeros = np.zeros((raw.shape[0], 1), dtype=raw.dtype)
             raw = np.concatenate([raw[:, :5], zeros, raw[:, 5:]], axis=1)
@@ -257,6 +264,55 @@ class TensorRTPoseEngine:
 
         return np.expand_dims(tensor, 0), ratio, (dw, dh)
 
+    def _xywh_to_xyxy(self, bbox_xywh):
+        cx, cy, w, h = bbox_xywh
+        x1 = cx - w / 2.0
+        y1 = cy - h / 2.0
+        x2 = cx + w / 2.0
+        y2 = cy + h / 2.0
+        return [x1, y1, x2, y2]
+
+    def _bbox_iou_xyxy(self, box1, box2) -> float:
+        x1 = max(box1[0], box2[0])
+        y1 = max(box1[1], box2[1])
+        x2 = min(box1[2], box2[2])
+        y2 = min(box1[3], box2[3])
+
+        inter_w = max(0.0, x2 - x1)
+        inter_h = max(0.0, y2 - y1)
+        inter = inter_w * inter_h
+
+        area1 = max(0.0, box1[2] - box1[0]) * max(0.0, box1[3] - box1[1])
+        area2 = max(0.0, box2[2] - box2[0]) * max(0.0, box2[3] - box2[1])
+        union = area1 + area2 - inter
+
+        if union <= 0.0:
+            return 0.0
+        return inter / union
+
+    def _nms(self, detections: List[PoseDetection]) -> List[PoseDetection]:
+        if not detections:
+            return []
+
+        detections = sorted(detections, key=lambda d: d.bbox_conf, reverse=True)
+        kept = []
+
+        while detections and len(kept) < self.max_det:
+            best = detections.pop(0)
+            kept.append(best)
+            best_xyxy = self._xywh_to_xyxy(best.bbox_xywh)
+
+            remain = []
+            for det in detections:
+                det_xyxy = self._xywh_to_xyxy(det.bbox_xywh)
+                iou = self._bbox_iou_xyxy(best_xyxy, det_xyxy)
+                if iou < self.iou_thres:
+                    remain.append(det)
+
+            detections = remain
+
+        return kept
+
     def _postprocess(self, raw, orig_shape, ratio, pad):
         oh, ow = orig_shape
         detections = []
@@ -264,11 +320,13 @@ class TensorRTPoseEngine:
             conf = float(row[4])
             if conf < self.conf_thres:
                 continue
+
             cx, cy, w, h = row[:4]
             cx = (cx - pad[0]) / ratio
             cy = (cy - pad[1]) / ratio
             w = w / ratio
             h = h / ratio
+
             keypoints = []
             kpt = row[6:].reshape(-1, 3)[:17]
             for x, y, kconf in kpt:
@@ -277,11 +335,21 @@ class TensorRTPoseEngine:
                 if kconf < self.kpt_thres:
                     keypoints.append([0.0, 0.0, 0.0])
                 else:
-                    keypoints.append([float(np.clip(x, 0, ow - 1)), float(np.clip(y, 0, oh - 1)), float(kconf)])
+                    keypoints.append([
+                        float(np.clip(x, 0, ow - 1)),
+                        float(np.clip(y, 0, oh - 1)),
+                        float(kconf)
+                    ])
+
             detections.append(PoseDetection(
-                bbox_xywh=[float(np.clip(cx, 0, ow - 1)), float(np.clip(cy, 0, oh - 1)), float(max(w, 0.0)), float(max(h, 0.0))],
+                bbox_xywh=[
+                    float(np.clip(cx, 0, ow - 1)),
+                    float(np.clip(cy, 0, oh - 1)),
+                    float(max(w, 0.0)),
+                    float(max(h, 0.0))
+                ],
                 bbox_conf=conf,
                 keypoints=keypoints,
             ))
-        detections.sort(key=lambda d: d.bbox_conf, reverse=True)
-        return detections
+
+        return self._nms(detections)

--- a/LayerSensing/Pose/PoseEngine.py
+++ b/LayerSensing/Pose/PoseEngine.py
@@ -67,11 +67,31 @@ class TensorRTPoseEngine:
         return True
 
     def infer(self, image: np.ndarray) -> List[PoseDetection]:
+        batch_result = self.infer_batch([image])
+        return batch_result[0] if batch_result else []
+
+    def infer_batch(self, images: List[np.ndarray]) -> List[List[PoseDetection]]:
         if not self._load_ok:
+            return [[] for _ in images]
+        if len(images) == 0:
             return []
-        input_tensor, ratio, pad = self._preprocess(image)
+
+        input_tensors = []
+        preprocess_infos = []
+        for image in images:
+            input_tensor, ratio, pad = self._preprocess(image)
+            input_tensors.append(input_tensor[0])
+            preprocess_infos.append((image.shape[:2], ratio, pad))
+
+        input_tensor = np.stack(input_tensors, axis=0)
         raw = self._execute_trt(input_tensor)
-        return self._postprocess(raw, image.shape[:2], ratio, pad)
+        batch_raw = self._split_batch_raw(raw, expected_batch=len(images))
+
+        outputs = []
+        for idx, (orig_shape, ratio, pad) in enumerate(preprocess_infos):
+            per_raw = batch_raw[idx] if idx < len(batch_raw) else np.empty((0, 57), dtype=np.float32)
+            outputs.append(self._postprocess(per_raw, orig_shape, ratio, pad))
+        return outputs
 
     def _discover_io_names(self):
         input_name = None
@@ -127,7 +147,24 @@ class TensorRTPoseEngine:
         output_arrays = [item['host'].reshape(item['shape']) for item in io if not item['is_input']]
         if len(output_arrays) == 0:
             return np.empty((0, 57), dtype=np.float32)
-        return self._decode_raw_output(output_arrays[0])
+        return np.asarray(output_arrays[0], dtype=np.float32)
+
+    def _split_batch_raw(self, raw: np.ndarray, expected_batch: int) -> List[np.ndarray]:
+        raw = np.asarray(raw)
+        if raw.ndim == 0:
+            return [np.empty((0, 57), dtype=np.float32) for _ in range(expected_batch)]
+        if raw.ndim == 2:
+            return [self._decode_raw_output(raw) for _ in range(expected_batch)]
+        if raw.ndim == 3:
+            if raw.shape[0] == expected_batch:
+                return [self._decode_raw_output(raw[i]) for i in range(expected_batch)]
+            if raw.shape[0] == 1 and expected_batch == 1:
+                return [self._decode_raw_output(raw[0])]
+            if raw.shape[1] == expected_batch:
+                return [self._decode_raw_output(raw[:, i, :]) for i in range(expected_batch)]
+
+        decoded = self._decode_raw_output(raw)
+        return [decoded for _ in range(expected_batch)]
 
     def _prepare_io_buffers(self, input_tensor: np.ndarray):
         io = []

--- a/LayerSensing/Pose/PoseMqtt.py
+++ b/LayerSensing/Pose/PoseMqtt.py
@@ -1,27 +1,35 @@
 import json
 import logging
-import os
 import threading
 import time
-
-import cv2
+import os
+import math
 
 from LayerSensing.Pose.PoseEngine import TensorRTPoseEngine
 
 
 class PoseMqtt(threading.Thread):
-    def __init__(self, nodename, data_handler, frame_queue, engine_path: str, vis_dir: str = None, batch_size: int = 1):
+    def __init__(self, nodename, data_handler, frame_queue, batch_size: int, engine_path: str, output_json: str):
         super().__init__(name=nodename)
         self.nodename = nodename
         self.data_handler = data_handler
         self.frame_queue = frame_queue
-        self.engine = TensorRTPoseEngine(engine_path=engine_path)
-        self.vis_dir = vis_dir
         self.batch_size = max(int(batch_size), 1)
+        self.engine = TensorRTPoseEngine(engine_path=engine_path)
+        self.output_json = output_json
         self._stopper = threading.Event()
         self._counter = 0
         self._lat_acc = 0.0
         self._window_start = time.time()
+
+    def _ensure_json_output(self):
+        os.makedirs(os.path.dirname(self.output_json), exist_ok=True)
+        if not os.path.exists(self.output_json):
+            open(self.output_json, 'w').close()
+
+    def _append_pose_json(self, payload):
+        with open(self.output_json, 'a') as jsonfile:
+            jsonfile.write(json.dumps(payload, ensure_ascii=False) + '\n')
 
     def stop(self):
         self._stopper.set()
@@ -30,6 +38,7 @@ class PoseMqtt(threading.Thread):
         return self._stopper.is_set()
 
     def run(self):
+        self._ensure_json_output()
         if not self.engine.load():
             logging.error('%s failed to load pose engine, pipeline stopped.', self.nodename)
             return
@@ -42,7 +51,9 @@ class PoseMqtt(threading.Thread):
                     if pending_frames:
                         self._process_batch(pending_frames)
                         pending_frames = []
-                    self.data_handler.publish('pose', json.dumps({'frame_id': frame.index, 'timestamp': frame.monotonic_timestamp, 'bbox': [], 'kpts': [], 'EOF': True}))
+                    payload = {'frame_id': frame.index, 'timestamp': frame.monotonic_timestamp, 'detection': [], 'EOF': True}
+                    self.data_handler.publish('pose', json.dumps(payload))
+                    self._append_pose_json(payload)
                     logging.info('%s EOF reached', self.nodename)
                     break
 
@@ -57,7 +68,7 @@ class PoseMqtt(threading.Thread):
             except Exception as e:
                 logging.error('%s infer/publish failed: %s', self.nodename, e)
                 frame.release()
-
+                
         for pending in pending_frames:
             pending.release()
 
@@ -74,75 +85,44 @@ class PoseMqtt(threading.Thread):
 
             for idx, frame in enumerate(frames):
                 detections = batch_detections[idx] if idx < len(batch_detections) else []
-                best_det = detections[0] if detections else None
-                payload = self._build_payload(frame, best_det)
+                payload = self._build_payload(frame, detections)
                 self.data_handler.publish('pose', json.dumps(payload))
-                self._save_visualization(frame, detections)
+                self._append_pose_json(payload)
         finally:
             for frame in frames:
                 frame.release()
 
-    def _build_payload(self, frame, detection):
+    def _build_payload(self, frame, detections):
         h, w = frame.image.shape[:2]
         payload = {
             'frame_id': frame.index,
             'timestamp': frame.monotonic_timestamp,
-            'bbox': [],
-            'kpts': [],
+            'detection': [],
         }
-        if detection is None:
-            return payload
 
-        cx, cy, bw, bh = detection.bbox_xywh
-        payload['bbox'] = [
-            float(min(max(cx / w, 0.0), 1.0)) if w else 0.0,
-            float(min(max(cy / h, 0.0), 1.0)) if h else 0.0,
-            float(min(max(bw / w, 0.0), 1.0)) if w else 0.0,
-            float(min(max(bh / h, 0.0), 1.0)) if h else 0.0,
-            float(detection.bbox_conf),
-        ]
-        payload['kpts'] = [
-            [
-                float(min(max(x / w, 0.0), 1.0)) if w else 0.0,
-                float(min(max(y / h, 0.0), 1.0)) if h else 0.0,
+        top_detections = (detections or [])[:2]
+        for det in top_detections:
+            cx, cy, bw, bh = det.bbox_xywh
+            bbox = [
+                round(float(min(max(cx / w, 0.0), 1.0)) if w else 0.0, 5),
+                round(float(min(max(cy / h, 0.0), 1.0)) if h else 0.0, 5),
+                round(float(min(max(bw / w, 0.0), 1.0)) if w else 0.0, 5),
+                round(float(min(max(bh / h, 0.0), 1.0)) if h else 0.0, 5),
+                round(float(det.bbox_conf), 3),
             ]
-            for x, y, _ in detection.keypoints[:17]
-        ]
-        while len(payload['kpts']) < 17:
-            payload['kpts'].append([0.0, 0.0])
+            kpts = []
+            for x, y, _ in det.keypoints[:17]:
+                kpts.append(round(float(min(max(x / w, 0.0), 1.0)) if w else 0.0, 5))
+                kpts.append(round(float(min(max(y / h, 0.0), 1.0)) if h else 0.0, 5))
+            while len(kpts) < 34:
+                kpts.extend([0.0, 0.0])
+
+            payload['detection'].append({
+                'bbox': bbox,
+                'kpts': kpts,
+            })
+
         return payload
-
-    def _save_visualization(self, frame, detections):
-        if not self.vis_dir:
-            return
-
-        image = frame.image
-        if image is None:
-            return
-
-        if image.ndim == 2:
-            vis = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
-        elif image.ndim == 3 and image.shape[2] == 1:
-            vis = cv2.cvtColor(image[:, :, 0], cv2.COLOR_GRAY2BGR)
-        else:
-            vis = image.copy()
-
-        for det in detections:
-            cx, cy, w, h = det.bbox_xywh
-            x1 = int(max(cx - w / 2.0, 0))
-            y1 = int(max(cy - h / 2.0, 0))
-            x2 = int(min(cx + w / 2.0, vis.shape[1] - 1))
-            y2 = int(min(cy + h / 2.0, vis.shape[0] - 1))
-            cv2.rectangle(vis, (x1, y1), (x2, y2), (0, 255, 0), 2)
-
-            for x, y, kconf in det.keypoints:
-                if kconf <= 0:
-                    continue
-                cv2.circle(vis, (int(x), int(y)), 2, (0, 255, 255), -1)
-
-        os.makedirs(self.vis_dir, exist_ok=True)
-        save_path = os.path.join(self.vis_dir, f'{frame.index}.png')
-        cv2.imwrite(save_path, vis)
 
     def _log_perf(self, latency_ms: float):
         now = time.time()

--- a/LayerSensing/Pose/PoseMqtt.py
+++ b/LayerSensing/Pose/PoseMqtt.py
@@ -10,13 +10,14 @@ from LayerSensing.Pose.PoseEngine import TensorRTPoseEngine
 
 
 class PoseMqtt(threading.Thread):
-    def __init__(self, nodename, data_handler, frame_queue, engine_path: str, vis_dir: str = None):
+    def __init__(self, nodename, data_handler, frame_queue, engine_path: str, vis_dir: str = None, batch_size: int = 1):
         super().__init__(name=nodename)
         self.nodename = nodename
         self.data_handler = data_handler
         self.frame_queue = frame_queue
         self.engine = TensorRTPoseEngine(engine_path=engine_path)
         self.vis_dir = vis_dir
+        self.batch_size = max(int(batch_size), 1)
         self._stopper = threading.Event()
         self._counter = 0
         self._lat_acc = 0.0
@@ -33,31 +34,53 @@ class PoseMqtt(threading.Thread):
             logging.error('%s failed to load pose engine, pipeline stopped.', self.nodename)
             return
         logging.info('%s pipeline started', self.nodename)
+        pending_frames = []
         while not self._stopped():
             frame = self.frame_queue.pop(True)
             try:
                 if frame.is_eos:
+                    if pending_frames:
+                        self._process_batch(pending_frames)
+                        pending_frames = []
                     self.data_handler.publish('pose', json.dumps({'frame_id': frame.index, 'timestamp': frame.monotonic_timestamp, 'bbox': [], 'kpts': [], 'EOF': True}))
                     logging.info('%s EOF reached', self.nodename)
                     break
 
-                t0 = time.perf_counter()
-                detections = self.engine.infer(frame.image)
-                latency_ms = (time.perf_counter() - t0) * 1000.0
-                self._lat_acc += latency_ms
-                self._counter += 1
-                self._log_perf(latency_ms)
+                if self.batch_size == 1:
+                    self._process_batch([frame])
+                    continue
 
+                pending_frames.append(frame)
+                if len(pending_frames) >= self.batch_size:
+                    self._process_batch(pending_frames)
+                    pending_frames = []
+            except Exception as e:
+                logging.error('%s infer/publish failed: %s', self.nodename, e)
+                frame.release()
+
+        for pending in pending_frames:
+            pending.release()
+
+        logging.info('%s pipeline stopped', self.nodename)
+
+    def _process_batch(self, frames):
+        try:
+            t0 = time.perf_counter()
+            batch_detections = self.engine.infer_batch([f.image for f in frames])
+            latency_ms = (time.perf_counter() - t0) * 1000.0
+            self._lat_acc += latency_ms
+            self._counter += len(frames)
+            self._log_perf(latency_ms)
+
+            for idx, frame in enumerate(frames):
+                detections = batch_detections[idx] if idx < len(batch_detections) else []
                 best_det = detections[0] if detections else None
                 payload = self._build_payload(frame, best_det)
                 self.data_handler.publish('pose', json.dumps(payload))
                 self._save_visualization(frame, detections)
-            except Exception as e:
-                logging.error('%s infer/publish failed: %s', self.nodename, e)
-            finally:
+        finally:
+            for frame in frames:
                 frame.release()
-
-        logging.info('%s pipeline stopped', self.nodename)
 
     def _build_payload(self, frame, detection):
         h, w = frame.image.shape[:2]

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -8,6 +8,7 @@ class PoseManager:
     DEFAULT_ENGINE_BY_VERSION = {
         'batch1': 'int8.engine',
         'batch3': 'int8_batch3.engine',
+        'batch10': 'int8_batch10.engine',
     }
 
     def __init__(self, data_handler, distributor):
@@ -39,7 +40,8 @@ class PoseManager:
             os.makedirs(pose_vis_dir, exist_ok=True)
 
             self.distributor.activate_pose(True)
-            self.poseThread = PoseMqtt('Pose', self.data_handler, self.distributor.pose_queue, engine_path, pose_vis_dir, batch_size=1 if version == 'batch1' else 3)
+            batch_size = {'batch1': 1, 'batch3': 3, 'batch10': 10}[version]
+            self.poseThread = PoseMqtt('Pose', self.data_handler, self.distributor.pose_queue, engine_path, pose_vis_dir, batch_size=batch_size)
             self.poseThread.start()
             return {'status': 'ready'}
         except Exception as e:

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -5,25 +5,41 @@ from lib.common import ROOTDIR
 
 
 class PoseManager:
+    DEFAULT_ENGINE_BY_VERSION = {
+        'batch1': 'int8.engine',
+        'batch3': 'int8_batch3.engine',
+    }
+
     def __init__(self, data_handler, distributor):
         self.data_handler = data_handler
         self.distributor = distributor
         self.poseThread = None
 
-    def startPose(self, camera_origin_size: 'tuple[int, int]' = (640, 480), engine_filename: str = 'int8.engine', replay_dirname: str = '', cam_idx: int = 0):
+    def startPose(self,
+                  camera_origin_size: 'tuple[int, int]' = (640, 480),
+                  engine_version: str = 'batch1',
+                  engine_filename: str = '',
+                  replay_dirname: str = '',
+                  cam_idx: int = 0):
         try:
             if self.poseThread is not None:
                 raise Exception('There is another Pose thread is running.')
-            engine_path = engine_filename
+
+            version = (engine_version or 'batch1').lower()
+            if version not in self.DEFAULT_ENGINE_BY_VERSION:
+                raise Exception(f'Unsupported pose engine version: {engine_version}. Support: {list(self.DEFAULT_ENGINE_BY_VERSION.keys())}')
+
+            selected_engine = engine_filename or self.DEFAULT_ENGINE_BY_VERSION[version]
+            engine_path = selected_engine
             if not os.path.isabs(engine_path):
-                engine_path = f'{ROOTDIR}/LayerSensing/Pose/weights/{engine_filename}'
+                engine_path = f'{ROOTDIR}/LayerSensing/Pose/weights/{selected_engine}'
 
             replay_path = f'{ROOTDIR}/replay/{replay_dirname}' if replay_dirname else f'{ROOTDIR}/replay'
             pose_vis_dir = f'{replay_path}/pose'
             os.makedirs(pose_vis_dir, exist_ok=True)
 
             self.distributor.activate_pose(True)
-            self.poseThread = PoseMqtt('Pose', self.data_handler, self.distributor.pose_queue, engine_path, pose_vis_dir)
+            self.poseThread = PoseMqtt('Pose', self.data_handler, self.distributor.pose_queue, engine_path, pose_vis_dir, batch_size=1 if version == 'batch1' else 3)
             self.poseThread.start()
             return {'status': 'ready'}
         except Exception as e:

--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -42,14 +42,16 @@ class RpcSensing(RemoteProcedureCall):
         return self._call_rpc_sync("TrackNet/stopDatafeeder")
 
     def startPose(self, camera_origin_size:'tuple[int, int]' = (640, 480),
-                  engine_filename: str = "int8.engine",
+                  engine_version: str = "batch1",
+                  engine_filename: str = "",
                   replay_dirname: str = "",
                   cam_idx: int = 0):
         """Start Pose thread
 
         Args:
             camera_origin_size (tuple[int, int]): 相機原始解析度 (目前保留欄位，便於和 TrackNet 對齊)
-            engine_filename (str): TensorRT engine filename or absolute path.
+            engine_version (str): 引擎版本，支援 "batch1" 或 "batch3"。
+            engine_filename (str): TensorRT engine filename or absolute path，留空字串時依版本使用預設權重。
             replay_dirname (str): 儲存資料夾名稱 (目前保留欄位，便於和 TrackNet 對齊)
             cam_idx (int): 相機編號 (目前保留欄位，便於和 TrackNet 對齊)
 
@@ -58,6 +60,7 @@ class RpcSensing(RemoteProcedureCall):
         """
         return self._call_rpc_sync("Pose/start",
                                    camera_origin_size=camera_origin_size,
+                                   engine_version=engine_version,
                                    engine_filename=engine_filename,
                                    replay_dirname=replay_dirname,
                                    cam_idx=cam_idx)

--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -50,7 +50,7 @@ class RpcSensing(RemoteProcedureCall):
 
         Args:
             camera_origin_size (tuple[int, int]): 相機原始解析度 (目前保留欄位，便於和 TrackNet 對齊)
-            engine_version (str): 引擎版本，支援 "batch1" 或 "batch3"。
+            engine_version (str): 引擎版本，支援 "batch1"、"batch3" 或 "batch10"。
             engine_filename (str): TensorRT engine filename or absolute path，留空字串時依版本使用預設權重。
             replay_dirname (str): 儲存資料夾名稱 (目前保留欄位，便於和 TrackNet 對齊)
             cam_idx (int): 相機編號 (目前保留欄位，便於和 TrackNet 對齊)

--- a/test_app.py
+++ b/test_app.py
@@ -20,7 +20,7 @@ def parse_args():
     parser.add_argument("--tracknet_ver", default="tracknet_v2")
     parser.add_argument("--tracknet_weights", default="no114_30.tar")
     parser.add_argument("--pose_engine", default="int8.engine")
-    parser.add_argument("--pose_engine_version", default="batch1", choices=["batch1", "batch3"])
+    parser.add_argument("--pose_engine_version", default="batch1", choices=["batch1", "batch3", "batch10"])
     parser.add_argument("--cam_idx", type=int, default=0)
     parser.add_argument("--camera_width", type=int, default=640)
     parser.add_argument("--camera_height", type=int, default=480)

--- a/test_app.py
+++ b/test_app.py
@@ -20,6 +20,7 @@ def parse_args():
     parser.add_argument("--tracknet_ver", default="tracknet_v2")
     parser.add_argument("--tracknet_weights", default="no114_30.tar")
     parser.add_argument("--pose_engine", default="int8.engine")
+    parser.add_argument("--pose_engine_version", default="batch1", choices=["batch1", "batch3"])
     parser.add_argument("--cam_idx", type=int, default=0)
     parser.add_argument("--camera_width", type=int, default=640)
     parser.add_argument("--camera_height", type=int, default=480)
@@ -43,7 +44,13 @@ def main():
     ret = sensing.startTrackNet((args.camera_width, args.camera_height), args.tracknet_ver, args.tracknet_weights, replay_dirname, args.cam_idx)
     print(f"TrackNet: {ret}")
 
-    pose_ret = sensing.startPose((args.camera_width, args.camera_height), args.pose_engine, replay_dirname, args.cam_idx)
+    pose_ret = sensing.startPose(
+        (args.camera_width, args.camera_height),
+        engine_version=args.pose_engine_version,
+        engine_filename=args.pose_engine,
+        replay_dirname=replay_dirname,
+        cam_idx=args.cam_idx,
+    )
     print(f"Pose: {pose_ret}")
 
     duration = camera.startVideoFeeder(args.video)


### PR DESCRIPTION
### Motivation
- Enable batched pose inference to improve throughput and support different TensorRT engine variants (single-frame and batch-3 engines).
- Expose engine version selection so the system can choose appropriate default engine filenames for different batch sizes.

### Description
- Implemented `infer_batch` in `LayerSensing/Pose/PoseEngine.py` and added `_split_batch_raw` plus adjustments to `_execute_trt` to return raw arrays for postprocessing, enabling multi-image inference handling and proper decoding per item. 
- Updated `LayerSensing/Pose/PoseMqtt.py` to buffer incoming frames, add a `batch_size` parameter, and process frames in `_process_batch` to publish batched results and preserve latency accounting. 
- Added engine-version to the manager and RPC layers by introducing `DEFAULT_ENGINE_BY_VERSION` and selecting engines in `LayerSensing/PoseManager.py`, and changed RPC signature in `LayerSensing/RpcSensing.py` to accept `engine_version`. 
- Updated `test_app.py` to accept a `--pose_engine_version` argument and forward `engine_version` and `engine_filename` to `startPose` for easier local testing.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b6f0774c8323a4fbe449b109f0b6)