### PR TITLE
Add Pose enable/disable UI and live skeleton overlay on camera preview

### DIFF
--- a/LayerApplication/Rpc/RpcStreamingBadminton.py
+++ b/LayerApplication/Rpc/RpcStreamingBadminton.py
@@ -15,9 +15,11 @@ class RpcStreamingBadminton:
         self.mqttc:mqtt.Client = manager.mqttc
 
         self.sensing_topics = {}
+        self.pose_topics = {}
 
         for idx, agent in self.manager.sensingLayerAgents.items():
             self.sensing_topics[idx] = f'/DATA/{agent.device_name}/SensingLayer/TrackNet'
+            self.pose_topics[idx] = f'/DATA/{agent.device_name}/SensingLayer/Pose'
 
         self.content_topic_point = ""
         self.content_topic_event = ""
@@ -29,6 +31,7 @@ class RpcStreamingBadminton:
             self.content_topic_segment = f'/DATA/{self.manager.contentLayerAgent.device_name}/ContentLayer/Model3D/Segment'
 
         self.sensing_callbacks = {}
+        self.pose_callbacks = {}
         self.content_callback_point = None
         self.content_callback_event = None
         self.content_callback_segment = None
@@ -53,6 +56,11 @@ class RpcStreamingBadminton:
             if (callback := self.sensing_callbacks.get(idx, None)) is not None:
                 self.mqttc.subscribe(topic)
                 self.mqttc.message_callback_add(topic, self._func_wrapper(callback))
+        # setup pose callback
+        for idx, topic in self.pose_topics.items():
+            if (callback := self.pose_callbacks.get(idx, None)) is not None:
+                self.mqttc.subscribe(topic)
+                self.mqttc.message_callback_add(topic, self._func_wrapper(callback))
         # setup content callback
         if self.content_topic_point:
             if (callback := self.content_callback_point) is not None:
@@ -69,6 +77,9 @@ class RpcStreamingBadminton:
 
     def _setupUnsubscribe(self):
         for _, topic in self.sensing_topics.items():
+            self.mqttc.unsubscribe(topic)
+            self.mqttc.message_callback_remove(topic)
+        for _, topic in self.pose_topics.items():
             self.mqttc.unsubscribe(topic)
             self.mqttc.message_callback_remove(topic)
         if self.content_topic_point:
@@ -166,7 +177,7 @@ class RpcStreamingBadminton:
 
         self._setupUnsubscribe()
 
-    def start(self, content_mode="CES", tracknet_ver="tracknet_v2", record_mode="h264_high"):
+    def start(self, content_mode="CES", tracknet_ver="tracknet_v2", record_mode="h264_high", pose_ver="OFF", pose_weight=""):
         """Start
 
         Args:
@@ -215,6 +226,19 @@ class RpcStreamingBadminton:
                 ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_v2", "no114_30.tar", replay_dirname, cam_idx)
                 logging.info(f"TrackNet_{cam_idx}: {str(ret)}")
 
+        # ====== Setup pose ======
+        pose_enabled = pose_ver != "OFF"
+        if pose_enabled:
+            for cam_idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
+                cameraAgent = self.manager.cameraLayerAgents[cam_idx]
+                pose_engine_filename = "" if pose_weight == "default" else pose_weight
+                ret = sensingAgent.startPose(camera_origin_size=cameraAgent.resolution,
+                                             engine_version=pose_ver,
+                                             engine_filename=pose_engine_filename,
+                                             replay_dirname=replay_dirname,
+                                             cam_idx=cam_idx)
+                logging.info(f"Pose_{cam_idx}: {str(ret)}")
+
         # ====== Setup camera ======
 
         async def startCamera():
@@ -248,6 +272,8 @@ class RpcStreamingBadminton:
         for idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
             ret = sensingAgent.stopTrackNet()
             logging.info(f"TrackNet_{idx}: {str(ret)}")
+            ret_pose = sensingAgent.stopPose()
+            logging.info(f"Pose_{idx}: {str(ret_pose)}")
 
         # ====== Stop content ======
         ret = self.manager.contentLayerAgent.stopModel3D()

--- a/LayerApplication/UI/Debug/StreamingDemoPage.py
+++ b/LayerApplication/UI/Debug/StreamingDemoPage.py
@@ -30,6 +30,10 @@ class StreamingDemoPage(QGroupBox):
     signal_content_point = pyqtSignal(bytes)
     signal_content_event = pyqtSignal(bytes)
     signal_content_segment = pyqtSignal(bytes)
+    signal_pose_0 = pyqtSignal(bytes)
+    signal_pose_1 = pyqtSignal(bytes)
+    signal_pose_2 = pyqtSignal(bytes)
+    signal_pose_3 = pyqtSignal(bytes)
 
     def __init__(self, rpcStreamingBadminton:RpcStreamingBadminton, rpcCameraWidget:RpcCameraWidget):
         super().__init__()
@@ -47,6 +51,10 @@ class StreamingDemoPage(QGroupBox):
         self.signal_content_point.connect(self.content_callback_point)
         self.signal_content_event.connect(self.content_callback_event)
         self.signal_content_segment.connect(self.content_callback_segment)
+        self.signal_pose_0.connect(self.pose_callback_0)
+        self.signal_pose_1.connect(self.pose_callback_1)
+        self.signal_pose_2.connect(self.pose_callback_2)
+        self.signal_pose_3.connect(self.pose_callback_3)
 
     def hideEvent(self, event):
         logging.debug(f"{self.__class__.__name__}: hided.")
@@ -59,6 +67,10 @@ class StreamingDemoPage(QGroupBox):
         self.rpcStreamingBadminton.content_callback_point = None
         self.rpcStreamingBadminton.content_callback_event = None
         self.rpcStreamingBadminton.content_callback_segment = None
+        self.rpcStreamingBadminton.pose_callbacks[0] = None
+        self.rpcStreamingBadminton.pose_callbacks[1] = None
+        self.rpcStreamingBadminton.pose_callbacks[2] = None
+        self.rpcStreamingBadminton.pose_callbacks[3] = None
 
     def deleteUI(self):
         self.rpcCameraWidget.show()
@@ -75,6 +87,10 @@ class StreamingDemoPage(QGroupBox):
         self.rpcStreamingBadminton.content_callback_point = lambda x: self.signal_content_point.emit(x)
         self.rpcStreamingBadminton.content_callback_event = lambda x: self.signal_content_event.emit(x)
         self.rpcStreamingBadminton.content_callback_segment = lambda x: self.signal_content_segment.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[0] = lambda x: self.signal_pose_0.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[1] = lambda x: self.signal_pose_1.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[2] = lambda x: self.signal_pose_2.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[3] = lambda x: self.signal_pose_3.emit(x)
 
         logging.debug(f"{self.__class__.__name__}: shown.")
 
@@ -110,6 +126,7 @@ class StreamingDemoPage(QGroupBox):
 
         self.trajectory_widget.reset()
         self.ball_point_widget.reset()
+        self.rpcCameraWidget.clearPosePoint()
 
     def startTest(self):
         self._clearOutput()
@@ -138,14 +155,17 @@ class StreamingDemoPage(QGroupBox):
             content_mode = self.combo_mode.currentText()
             record_mode = self.combo_record_mode.currentText()
             tracknet_ver = self.combo_tracknet_ver.currentText()
+            pose_ver = self.combo_pose_ver.currentText()
+            pose_weight = self.combo_pose_weight.currentText()
 
-            self.rpcStreamingBadminton.start(content_mode=content_mode, tracknet_ver=tracknet_ver, record_mode=record_mode)
+            self.rpcStreamingBadminton.start(content_mode=content_mode, tracknet_ver=tracknet_ver, record_mode=record_mode, pose_ver=pose_ver, pose_weight=pose_weight)
             self.btn_run.setText(f"Stop")
         else:
             self.rpcStreamingBadminton.stop()
             self.btn_run.setText("Run")
             self.trajectory_widget.render()
             self.ball_point_widget.reset()
+            self.rpcCameraWidget.clearPosePoint()
         self.is_recording = not self.is_recording
 
     def sensing_callback_0(self, data:bytes):
@@ -188,6 +208,39 @@ class StreamingDemoPage(QGroupBox):
         points = [ (int(p['pos']['x']), int(p['pos']['y'])) for p in jdata['linear'] ]
 
         self.rpcCameraWidget.updateTrackNetPoint(3, points)
+
+    def _pose_callback(self, cam_idx:int, data:bytes):
+        try:
+            jdata = json.loads(data)
+            kpts = jdata.get('kpts', [])
+            if len(kpts) == 0:
+                self.rpcCameraWidget.updatePosePoint(cam_idx, [])
+                return
+
+            width, height = self.rpcCameraWidget.cameraList[cam_idx].resolution
+            points = []
+            for kp in kpts:
+                if len(kp) < 2:
+                    points.append((0, 0))
+                    continue
+                x = int(kp[0] * width)
+                y = int(kp[1] * height)
+                points.append((x, y))
+            self.rpcCameraWidget.updatePosePoint(cam_idx, points)
+        except Exception as e:
+            logging.error(f"處理 Pose 資料時發生錯誤 (cam_{cam_idx}): {e}")
+
+    def pose_callback_0(self, data:bytes):
+        self._pose_callback(0, data)
+
+    def pose_callback_1(self, data:bytes):
+        self._pose_callback(1, data)
+
+    def pose_callback_2(self, data:bytes):
+        self._pose_callback(2, data)
+
+    def pose_callback_3(self, data:bytes):
+        self._pose_callback(3, data)
 
     def content_callback_point(self, data:str):
         """處理球點資料"""
@@ -359,6 +412,24 @@ class StreamingDemoPage(QGroupBox):
         tracknet_ver_layout.addWidget(label_tracknet_ver, stretch=1)
         tracknet_ver_layout.addWidget(self.combo_tracknet_ver, stretch=2)
 
+        pose_ver_layout = QHBoxLayout()
+        label_pose_ver = QLabel("Pose Ver.:")
+        self.combo_pose_ver = QComboBox()
+        self.combo_pose_ver.addItems(["OFF", "batch1", "batch3", "batch10"])
+        self.combo_pose_ver.setCurrentText("OFF")
+        self.combo_pose_ver.currentTextChanged.connect(self.onPoseVerChanged)
+        pose_ver_layout.addWidget(label_pose_ver, stretch=1)
+        pose_ver_layout.addWidget(self.combo_pose_ver, stretch=2)
+
+        pose_weight_layout = QHBoxLayout()
+        label_pose_weight = QLabel("Pose Weight:")
+        self.combo_pose_weight = QComboBox()
+        self.combo_pose_weight.addItems(["default", "int8.engine", "int8_batch3.engine", "int8_batch10.engine"])
+        self.combo_pose_weight.setCurrentText("default")
+        self.combo_pose_weight.setEnabled(False)
+        pose_weight_layout.addWidget(label_pose_weight, stretch=1)
+        pose_weight_layout.addWidget(self.combo_pose_weight, stretch=2)
+
         self.btn_run = QPushButton()
         self.btn_run.setText('Run')
         self.btn_run.setFixedSize(QSize(160, 60))
@@ -375,9 +446,18 @@ class StreamingDemoPage(QGroupBox):
         container_layout.addWidget(self.btn_home)
         container_layout.addLayout(mode_layout)
         container_layout.addLayout(tracknet_ver_layout)
+        container_layout.addLayout(pose_ver_layout)
+        container_layout.addLayout(pose_weight_layout)
         container_layout.addLayout(record_mode_layout)
         container_layout.addWidget(self.btn_run)
         container_layout.addWidget(self.btn_debug_run)
         container.setLayout(container_layout)
 
         return container
+
+    def onPoseVerChanged(self, pose_ver:str):
+        pose_enabled = pose_ver != "OFF"
+        self.combo_pose_weight.setEnabled(pose_enabled)
+        if not pose_enabled:
+            self.combo_pose_weight.setCurrentText("default")
+            self.rpcCameraWidget.clearPosePoint()

--- a/LayerApplication/UI/Debug/StreamingDemoPage.py
+++ b/LayerApplication/UI/Debug/StreamingDemoPage.py
@@ -213,20 +213,32 @@ class StreamingDemoPage(QGroupBox):
     def _pose_callback(self, cam_idx:int, data:bytes):
         try:
             jdata = json.loads(data)
-            kpts = jdata.get('kpts', [])
-            if len(kpts) == 0:
+
+            detections = jdata.get('detection', [])
+            if len(detections) == 0:
                 self.rpcCameraWidget.updatePosePoint(cam_idx, [])
                 return
 
             width, height = self.rpcCameraWidget.cameraList[cam_idx].resolution
+            det = detections[0] if detections else {}
+            raw_kpts = det.get('kpts', [])
+
+            if len(raw_kpts) < 2:
+                self.rpcCameraWidget.updatePosePoint(cam_idx, [])
+                return
+
             points = []
-            for kp in kpts:
-                if len(kp) < 2:
-                    points.append((0, 0))
-                    continue
-                x = int(kp[0] * width)
-                y = int(kp[1] * height)
+            # kpts format: [x0, y0, x1, y1, ...]
+            for i in range(0, min(len(raw_kpts), 34), 2):
+                x_norm = raw_kpts[i]
+                y_norm = raw_kpts[i + 1] if i + 1 < len(raw_kpts) else 0.0
+                x = int(float(x_norm) * width)
+                y = int(float(y_norm) * height)
                 points.append((x, y))
+
+            while len(points) < 17:
+                points.append((0, 0))
+
             self.rpcCameraWidget.updatePosePoint(cam_idx, points)
         except Exception as e:
             logging.error(f"處理 Pose 資料時發生錯誤 (cam_{cam_idx}): {e}")

--- a/LayerApplication/UI/Debug/StreamingDemoPage.py
+++ b/LayerApplication/UI/Debug/StreamingDemoPage.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import time
 import json
+from pathlib import Path
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
@@ -20,7 +21,7 @@ from ..UISettings import *
 from ..Services import SystemService
 from lib.message import *
 
-from lib.common import ICONDIR
+from lib.common import ICONDIR, ROOTDIR
 
 class StreamingDemoPage(QGroupBox):
     signal_tracknet_0 = pyqtSignal(bytes)
@@ -417,18 +418,17 @@ class StreamingDemoPage(QGroupBox):
         self.combo_pose_ver = QComboBox()
         self.combo_pose_ver.addItems(["OFF", "batch1", "batch3", "batch10"])
         self.combo_pose_ver.setCurrentText("OFF")
-        self.combo_pose_ver.currentTextChanged.connect(self.onPoseVerChanged)
+        self.combo_pose_ver.currentTextChanged.connect(self._load_pose_weights)
         pose_ver_layout.addWidget(label_pose_ver, stretch=1)
         pose_ver_layout.addWidget(self.combo_pose_ver, stretch=2)
 
         pose_weight_layout = QHBoxLayout()
         label_pose_weight = QLabel("Pose Weight:")
         self.combo_pose_weight = QComboBox()
-        self.combo_pose_weight.addItems(["default", "int8.engine", "int8_batch3.engine", "int8_batch10.engine"])
-        self.combo_pose_weight.setCurrentText("default")
         self.combo_pose_weight.setEnabled(False)
         pose_weight_layout.addWidget(label_pose_weight, stretch=1)
         pose_weight_layout.addWidget(self.combo_pose_weight, stretch=2)
+        self._load_pose_weights()
 
         self.btn_run = QPushButton()
         self.btn_run.setText('Run')
@@ -455,9 +455,25 @@ class StreamingDemoPage(QGroupBox):
 
         return container
 
-    def onPoseVerChanged(self, pose_ver:str):
-        pose_enabled = pose_ver != "OFF"
-        self.combo_pose_weight.setEnabled(pose_enabled)
-        if not pose_enabled:
-            self.combo_pose_weight.setCurrentText("default")
+    def _load_pose_weights(self):
+        version = self.combo_pose_ver.currentText()
+        if version == "OFF":
+            self.combo_pose_weight.clear()
+            self.combo_pose_weight.setEnabled(False)
             self.rpcCameraWidget.clearPosePoint()
+            return
+
+        base_dir = Path(ROOTDIR) / "LayerSensing" / "Pose" / "weights"
+        allowed_suffixes = {".engine"}
+        default_weight = "int8.engine"
+
+        weights = []
+        if base_dir.exists():
+            weights = [p.name for p in sorted(base_dir.iterdir()) if p.is_file() and p.suffix.lower() in allowed_suffixes]
+
+        if not weights and default_weight:
+            weights.append(default_weight)
+
+        self.combo_pose_weight.clear()
+        self.combo_pose_weight.addItems(weights)
+        self.combo_pose_weight.setEnabled(bool(weights))

--- a/LayerCamera/RpcCameraWidget.py
+++ b/LayerCamera/RpcCameraWidget.py
@@ -71,6 +71,9 @@ class RpcCameraWidget(QWidget):
 
         self.kf:'list[tuple[float, float]]' = [(0.0, 0.0) for _ in range(self.num_cameras)]
         self.offsets = [0 for _ in range(self.num_cameras)]
+        self.visualize_tracknet = [[] for _ in range(self.num_cameras)]
+        self.visualize_pose_kpts = [[] for _ in range(self.num_cameras)]
+        self.visualize_pose_edges = [[] for _ in range(self.num_cameras)]
 
     def _calculateOffsets(self, i):
         ref_timestamp, ref_dt = self.kf[self.idx_list[0]]
@@ -180,6 +183,8 @@ class RpcCameraWidget(QWidget):
             self.camera_label_list[i].setFixedSize(self.image_size_h)
 
         self.visualize_tracknet = [[] for _ in range(num)]
+        self.visualize_pose_kpts = [[] for _ in range(num)]
+        self.visualize_pose_edges = [[] for _ in range(num)]
 
         asyncio.run(self._startCamera(num))
 
@@ -199,6 +204,22 @@ class RpcCameraWidget(QWidget):
             # Draw a point (small circle) at coordinates (x, y)
             for x, y in self.visualize_tracknet[cam_idx]:
                 context.arc(x, y, 5, 0, 2 * 3.14159)  # Circle with radius 5
+            context.fill()
+
+        # Draw pose skeleton lines (yellow)
+        if len(self.visualize_pose_edges[cam_idx]) > 0:
+            context.set_source_rgb(1.0, 1.0, 0.0)
+            context.set_line_width(2.0)
+            for (x1, y1), (x2, y2) in self.visualize_pose_edges[cam_idx]:
+                context.move_to(x1, y1)
+                context.line_to(x2, y2)
+            context.stroke()
+
+        # Draw pose keypoints (pink)
+        if len(self.visualize_pose_kpts[cam_idx]) > 0:
+            context.set_source_rgb(1.0, 0.41, 0.71)
+            for x, y in self.visualize_pose_kpts[cam_idx]:
+                context.arc(x, y, 2, 0, 2 * 3.14159)
             context.fill()
 
     def __createDisplayPipeline(self, idx):
@@ -251,18 +272,55 @@ class RpcCameraWidget(QWidget):
 
         PREVIEW_WIDTH, PREVIEW_HEIGHT = 320, 240
 
-        # rescale
-        coords = [(int(x/width*PREVIEW_WIDTH), int(y/height*PREVIEW_HEIGHT)) for x, y in coords]
+        coords = self._transformPreviewCoords(cam_idx, coords, width, height, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+
+        self.visualize_tracknet[cam_idx] = coords
+
+    def _transformPreviewCoords(self, cam_idx:int, coords:'list[(int, int)]', width:int, height:int, preview_width:int, preview_height:int):
+        transformed = [(int(x/width*preview_width), int(y/height*preview_height)) for x, y in coords]
 
         # rotation
         if self.cameraList[cam_idx].direction == 1:
-            coords = [(PREVIEW_WIDTH-y, x) for x, y in coords]
+            transformed = [(preview_width-y, x) for x, y in transformed]
         elif self.cameraList[cam_idx].direction == 2:
-            coords = [(PREVIEW_WIDTH-x, PREVIEW_HEIGHT-y) for x, y in coords]
+            transformed = [(preview_width-x, preview_height-y) for x, y in transformed]
         elif self.cameraList[cam_idx].direction == 3:
-            coords = [(y, PREVIEW_HEIGHT-x) for x, y in coords]
+            transformed = [(y, preview_height-x) for x, y in transformed]
 
-        self.visualize_tracknet[cam_idx] = coords
+        return transformed
+
+    def clearPosePoint(self):
+        for idx in range(len(self.visualize_pose_kpts)):
+            self.visualize_pose_kpts[idx] = []
+            self.visualize_pose_edges[idx] = []
+
+    def updatePosePoint(self, cam_idx:int, coords:'list[(int, int)]'=[]):
+        width, height = self.cameraList[cam_idx].resolution
+        PREVIEW_WIDTH, PREVIEW_HEIGHT = 320, 240
+
+        valid_points = [pt for pt in coords if pt[0] > 0 and pt[1] > 0]
+        transformed = self._transformPreviewCoords(cam_idx, valid_points, width, height, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+        self.visualize_pose_kpts[cam_idx] = transformed
+
+        coco_edges = [
+            (5, 7), (7, 9),
+            (6, 8), (8, 10),
+            (5, 6),
+            (5, 11), (6, 12), (11, 12),
+            (11, 13), (13, 15),
+            (12, 14), (14, 16)
+        ]
+
+        transformed_all = self._transformPreviewCoords(cam_idx, coords, width, height, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+        edges = []
+        for a, b in coco_edges:
+            if a >= len(coords) or b >= len(coords):
+                continue
+            if coords[a][0] <= 0 or coords[a][1] <= 0 or coords[b][0] <= 0 or coords[b][1] <= 0:
+                continue
+            edges.append((transformed_all[a], transformed_all[b]))
+
+        self.visualize_pose_edges[cam_idx] = edges
 
     def __startDisplay(self):
         if self.is_preview_playing:


### PR DESCRIPTION
### Motivation
- Provide a way to enable/disable Pose processing from the streaming debug UI and reuse the existing TrackNet-style control pattern. 
- When Pose is enabled, render detected skeletons on the camera preview so operators can visually verify pose outputs in real time. 
- Allow selecting a pose engine weight while making that control inactive when Pose is turned `OFF` so the feature can be fully disabled.

### Description
- Added `Pose Ver.` and `Pose Weight` controls to the debug control bar in `LayerApplication/UI/Debug/StreamingDemoPage.py`, including an `OFF` option and `onPoseVerChanged` logic to disable the weight selector when `OFF` is chosen. 
- Wired per-camera Pose MQTT callbacks and signals in `StreamingDemoPage.py` and implemented pose payload parsing to pixel coordinates, then forwarded them to the camera preview via `updatePosePoint`. 
- Extended `LayerApplication/Rpc/RpcStreamingBadminton.py` to register per-camera Pose topics, hook pose callbacks for subscribe/unsubscribe, and to start/stop Pose on sensing agents depending on the selected `pose_ver` and `pose_weight` passed from the UI. 
- Implemented overlay rendering and pose state in `LayerCamera/RpcCameraWidget.py` by adding storage for keypoints and edges, coordinate transformation helpers, `updatePosePoint`/`clearPosePoint` methods, and drawing code that renders small pink keypoints and yellow skeleton lines on top of existing TrackNet red points.

### Testing
- Ran `python -m py_compile LayerApplication/UI/Debug/StreamingDemoPage.py LayerApplication/Rpc/RpcStreamingBadminton.py LayerCamera/RpcCameraWidget.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50d88c14483239e6a07cb39e09f6d)