### PR TITLE
Manage CUDA context, support static-batch TensorRT, and improve Pose pipeline shutdown/EOS handling

### DIFF
--- a/LayerSensing/Pose/PoseEngine.py
+++ b/LayerSensing/Pose/PoseEngine.py
@@ -36,6 +36,7 @@ class TensorRTPoseEngine:
         self._load_ok = False
         self.trt = None
         self.cuda = None
+        self.cuda_context = None
         self.input_name = None
         self.output_names = []
 
@@ -43,9 +44,15 @@ class TensorRTPoseEngine:
         try:
             import tensorrt as trt
             import pycuda.driver as cuda
-            import pycuda.autoinit  # noqa: F401
         except Exception as e:
             logging.error('TensorRT dependencies not available: %s', e)
+            return False
+
+        try:
+            cuda.init()
+            self.cuda_context = cuda.Device(0).make_context()
+        except Exception as e:
+            logging.error('Failed to initialize CUDA context: %s', e)
             return False
 
         logger = trt.Logger(trt.Logger.WARNING)
@@ -54,11 +61,13 @@ class TensorRTPoseEngine:
             engine = runtime.deserialize_cuda_engine(f.read())
         if engine is None:
             logging.error('Failed to deserialize pose engine: %s', self.engine_path)
+            self.unload()
             return False
 
         context = engine.create_execution_context()
         if context is None:
             logging.error('Failed to create execution context for pose engine')
+            self.unload()
             return False
 
         self.runtime = runtime
@@ -70,10 +79,27 @@ class TensorRTPoseEngine:
         self.input_name, self.output_names = self._discover_io_names()
         if self.input_name is None or len(self.output_names) == 0:
             logging.error('Failed to discover TensorRT Pose I/O tensors')
+            self.unload()
             return False
         self._load_ok = True
         logging.info('Pose engine loaded: %s', self.engine_path)
         return True
+
+    def unload(self):
+        self._load_ok = False
+        self.stream = None
+        self.context = None
+        self.engine = None
+        self.runtime = None
+
+        if self.cuda_context is not None:
+            try:
+                self.cuda_context.pop()
+                self.cuda_context.detach()
+            except Exception as e:
+                logging.warning('Pose CUDA context cleanup warning: %s', e)
+            finally:
+                self.cuda_context = None
 
     def infer(self, image: np.ndarray) -> List[PoseDetection]:
         batch_result = self.infer_batch([image])
@@ -84,6 +110,7 @@ class TensorRTPoseEngine:
             return [[] for _ in images]
         if len(images) == 0:
             return []
+        original_batch = len(images)
 
         input_tensors = []
         preprocess_infos = []
@@ -93,14 +120,14 @@ class TensorRTPoseEngine:
             preprocess_infos.append((image.shape[:2], ratio, pad))
 
         input_tensor = np.stack(input_tensors, axis=0)
-        raw = self._execute_trt(input_tensor)
-        batch_raw = self._split_batch_raw(raw, expected_batch=len(images))
+        raw, executed_batch = self._execute_trt(input_tensor)
+        batch_raw = self._split_batch_raw(raw, expected_batch=executed_batch)
 
         outputs = []
         for idx, (orig_shape, ratio, pad) in enumerate(preprocess_infos):
             per_raw = batch_raw[idx] if idx < len(batch_raw) else np.empty((0, 57), dtype=np.float32)
             outputs.append(self._postprocess(per_raw, orig_shape, ratio, pad))
-        return outputs
+        return outputs[:original_batch]
 
     def _discover_io_names(self):
         input_name = None
@@ -124,8 +151,29 @@ class TensorRTPoseEngine:
 
         return input_name, output_names
 
-    def _execute_trt(self, input_tensor: np.ndarray) -> np.ndarray:
+    def _execute_trt(self, input_tensor: np.ndarray):
         assert self.context is not None and self.engine is not None
+
+        execute_batch = input_tensor.shape[0]
+        if hasattr(self.engine, 'get_tensor_shape'):
+            engine_input_shape = tuple(self.engine.get_tensor_shape(self.input_name))
+        else:
+            binding_idx = self.engine.get_binding_index(self.input_name)
+            engine_input_shape = tuple(self.engine.get_binding_shape(binding_idx))
+
+        if len(engine_input_shape) > 0 and engine_input_shape[0] > 0 and engine_input_shape[0] != execute_batch:
+            required_batch = int(engine_input_shape[0])
+            if required_batch > execute_batch:
+                pad_count = required_batch - execute_batch
+                pad_src = input_tensor[-1:] if execute_batch > 0 else np.zeros((1,) + tuple(input_tensor.shape[1:]), dtype=input_tensor.dtype)
+                pad_tensor = np.repeat(pad_src, pad_count, axis=0)
+                input_tensor = np.concatenate([input_tensor, pad_tensor], axis=0)
+                execute_batch = required_batch
+                logging.debug('Pose TRT static batch=%s, padded input batch from %s to %s', required_batch, required_batch - pad_count, required_batch)
+            else:
+                input_tensor = input_tensor[:required_batch]
+                execute_batch = required_batch
+                logging.warning('Pose TRT required batch=%s smaller than provided batch, truncating input', required_batch)
 
         if hasattr(self.context, 'set_input_shape'):
             self.context.set_input_shape(self.input_name, tuple(input_tensor.shape))
@@ -155,8 +203,8 @@ class TensorRTPoseEngine:
 
         output_arrays = [item['host'].reshape(item['shape']) for item in io if not item['is_input']]
         if len(output_arrays) == 0:
-            return np.empty((0, 57), dtype=np.float32)
-        return np.asarray(output_arrays[0], dtype=np.float32)
+            return np.empty((0, 57), dtype=np.float32), execute_batch
+        return np.asarray(output_arrays[0], dtype=np.float32), execute_batch
 
     def _split_batch_raw(self, raw: np.ndarray, expected_batch: int) -> List[np.ndarray]:
         raw = np.asarray(raw)

--- a/LayerSensing/Pose/PoseMqtt.py
+++ b/LayerSensing/Pose/PoseMqtt.py
@@ -38,41 +38,42 @@ class PoseMqtt(threading.Thread):
         return self._stopper.is_set()
 
     def run(self):
-        self._ensure_json_output()
-        if not self.engine.load():
-            logging.error('%s failed to load pose engine, pipeline stopped.', self.nodename)
-            return
-        logging.info('%s pipeline started', self.nodename)
         pending_frames = []
-        while not self._stopped():
-            frame = self.frame_queue.pop(True)
-            try:
-                if frame.is_eos:
-                    if pending_frames:
+        try:
+            self._ensure_json_output()
+            if not self.engine.load():
+                logging.error('%s failed to load pose engine, pipeline stopped.', self.nodename)
+                return
+            logging.info('%s pipeline started', self.nodename)
+            while not self._stopped():
+                frame = self.frame_queue.pop(True)
+                try:
+                    if frame.is_eos:
+                        if pending_frames:
+                            self._process_batch(pending_frames)
+                            pending_frames = []
+                        payload = {'frame_id': frame.index, 'timestamp': frame.monotonic_timestamp, 'detection': [], 'EOF': True}
+                        self.data_handler.publish('pose', json.dumps(payload))
+                        self._append_pose_json(payload)
+                        logging.info('%s EOF reached', self.nodename)
+                        break
+
+                    if self.batch_size == 1:
+                        self._process_batch([frame])
+                        continue
+
+                    pending_frames.append(frame)
+                    if len(pending_frames) >= self.batch_size:
                         self._process_batch(pending_frames)
                         pending_frames = []
-                    payload = {'frame_id': frame.index, 'timestamp': frame.monotonic_timestamp, 'detection': [], 'EOF': True}
-                    self.data_handler.publish('pose', json.dumps(payload))
-                    self._append_pose_json(payload)
-                    logging.info('%s EOF reached', self.nodename)
-                    break
-
-                if self.batch_size == 1:
-                    self._process_batch([frame])
-                    continue
-
-                pending_frames.append(frame)
-                if len(pending_frames) >= self.batch_size:
-                    self._process_batch(pending_frames)
-                    pending_frames = []
-            except Exception as e:
-                logging.error('%s infer/publish failed: %s', self.nodename, e)
-                frame.release()
-                
-        for pending in pending_frames:
-            pending.release()
-
-        logging.info('%s pipeline stopped', self.nodename)
+                except Exception as e:
+                    logging.error('%s infer/publish failed: %s', self.nodename, e)
+                    frame.release()
+        finally:
+            for pending in pending_frames:
+                pending.release()
+            self.engine.unload()
+            logging.info('%s pipeline stopped', self.nodename)
 
     def _process_batch(self, frames):
         try:

--- a/LayerSensing/PoseManager.py
+++ b/LayerSensing/PoseManager.py
@@ -1,5 +1,8 @@
 import os
+import queue
 
+from LayerCamera.CameraSystemC.recorder_module import Frame
+from LayerSensing.FrameDistributor import CONSUMER_POSE, SharedFrameState
 from LayerSensing.Pose.PoseMqtt import PoseMqtt
 from lib.common import ROOTDIR
 
@@ -38,23 +41,36 @@ class PoseManager:
             replay_path = f'{ROOTDIR}/replay/{replay_dirname}' if replay_dirname else f'{ROOTDIR}/replay'
             pose_vis_dir = f'{replay_path}/pose'
             os.makedirs(pose_vis_dir, exist_ok=True)
+            pose_json_path = f'{pose_vis_dir}/Pose_{cam_idx}.jsonl'
 
             self.distributor.activate_pose(True)
             batch_size = {'batch1': 1, 'batch3': 3, 'batch10': 10}[version]
-            self.poseThread = PoseMqtt('Pose', self.data_handler, self.distributor.pose_queue, engine_path, pose_vis_dir, batch_size=batch_size)
+            self.poseThread = PoseMqtt('Pose', self.data_handler, self.distributor.pose_queue, batch_size=batch_size, engine_path=engine_path, output_json=pose_json_path)
             self.poseThread.start()
             return {'status': 'ready'}
         except Exception as e:
             return {'status': 'failure', 'message': str(e)}
 
-    def stopPose(self):
+    def stopPose(self, wait_for_eos=False):
         try:
             if self.poseThread is None:
                 raise Exception('No pose is running')
-            self.distributor.activate_pose(False)
-            self.poseThread.stop()
+
+            if not wait_for_eos:
+                frame = Frame()
+                frame.is_eos = True
+                eos_state = SharedFrameState(frame=frame, need_mask=CONSUMER_POSE)
+                try:
+                    self.distributor.pose_queue.push_state(eos_state)
+                except queue.Full:
+                    dropped = self.distributor.pose_queue.pop_nowait_state()
+                    self.distributor.release(dropped, CONSUMER_POSE)
+                    self.distributor.pose_drop_count += 1
+                    self.distributor.pose_queue.push_state(eos_state)
+
             self.poseThread.join()
             self.poseThread = None
-            return {'status': 'stopped'}
+            self.distributor.activate_pose(False)
+            return {'status': 'stopped ' + ('(EOS reached)' if wait_for_eos else '(Force stop)')}
         except Exception as e:
             return {'status': 'failure', 'message': str(e)}

--- a/LayerSensing/RpcSensing.py
+++ b/LayerSensing/RpcSensing.py
@@ -65,10 +65,13 @@ class RpcSensing(RemoteProcedureCall):
                                    replay_dirname=replay_dirname,
                                    cam_idx=cam_idx)
 
-    def stopPose(self):
+    def stopPose(self, wait_for_eos=False):
         """Stop Pose thread
+
+        Args:
+            wait_for_eos (bool): True 時等待資料流自然結束，False 時主動塞入 EOS 強制停止。
 
         Returns:
             dict: 狀態
         """
-        return self._call_rpc_sync("Pose/stop", timeout=1000)
+        return self._call_rpc_sync("Pose/stop", wait_for_eos=wait_for_eos, timeout=1000)


### PR DESCRIPTION
### Motivation
- Avoid CUDA context/resource leaks and support TensorRT engines that require a static input batch size.
- Make the Pose pipeline stop/restart semantics more robust by supporting EOF injection and ensuring engine cleanup.
- Ensure batched inference returns correct per-frame results when engines pad or truncate batches.

### Description
- In `TensorRTPoseEngine` added explicit `cuda.init()` and a `cuda_context` from `Device.make_context()`, implemented `unload()` to pop/detach the CUDA context and clear runtime objects, and updated `load()` to cleanup on failures.
- Enhanced `_execute_trt` to detect the engine's input batch dimension and pad or truncate the input tensor to match a static batch size, and to return the actual executed batch size; updated `infer_batch` to handle the returned executed batch and trim outputs to the original input count.
- Reworked `PoseMqtt.run` into a `try/finally` structure that ensures `engine.load()` is called on startup, publishes EOF payloads, uses `_process_batch` for pending frames, and calls `self.engine.unload()` on exit to guarantee cleanup.
- Updated `PoseManager` to create per-camera JSONL output paths and pass `output_json` to `PoseMqtt`, added logic to optionally inject an EOS `SharedFrameState` into the queue in `stopPose(wait_for_eos=False)`, and adjusted imports accordingly.
- Updated `RpcSensing.stopPose` signature to accept `wait_for_eos` and forward it to the pose stop RPC.

### Testing
- Ran the project unit tests with `pytest` and all tests passed.
- Ran the code linter with `flake8` and no new lint errors were reported.
- Performed a CI smoke test that starts and stops the Pose pipeline using `startPose`/`stopPose` with both EOS-wait and forced-stop modes and observed successful startup, inference, and graceful shutdown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75c63cad48323962a65b2f2bb7dc3)