### PR TITLE
Add Pose OFF option and live skeleton overlay in streaming debug page

### DIFF
--- a/LayerApplication/Rpc/RpcStreamingBadminton.py
+++ b/LayerApplication/Rpc/RpcStreamingBadminton.py
@@ -15,9 +15,11 @@ class RpcStreamingBadminton:
         self.mqttc:mqtt.Client = manager.mqttc
 
         self.sensing_topics = {}
+        self.pose_topics = {}
 
         for idx, agent in self.manager.sensingLayerAgents.items():
             self.sensing_topics[idx] = f'/DATA/{agent.device_name}/SensingLayer/TrackNet'
+            self.pose_topics[idx] = f'/DATA/{agent.device_name}/SensingLayer/Pose'
 
         self.content_topic_point = ""
         self.content_topic_event = ""
@@ -29,6 +31,7 @@ class RpcStreamingBadminton:
             self.content_topic_segment = f'/DATA/{self.manager.contentLayerAgent.device_name}/ContentLayer/Model3D/Segment'
 
         self.sensing_callbacks = {}
+        self.pose_callbacks = {}
         self.content_callback_point = None
         self.content_callback_event = None
         self.content_callback_segment = None
@@ -53,6 +56,11 @@ class RpcStreamingBadminton:
             if (callback := self.sensing_callbacks.get(idx, None)) is not None:
                 self.mqttc.subscribe(topic)
                 self.mqttc.message_callback_add(topic, self._func_wrapper(callback))
+        # setup pose callback
+        for idx, topic in self.pose_topics.items():
+            if (callback := self.pose_callbacks.get(idx, None)) is not None:
+                self.mqttc.subscribe(topic)
+                self.mqttc.message_callback_add(topic, self._func_wrapper(callback))
         # setup content callback
         if self.content_topic_point:
             if (callback := self.content_callback_point) is not None:
@@ -69,6 +77,9 @@ class RpcStreamingBadminton:
 
     def _setupUnsubscribe(self):
         for _, topic in self.sensing_topics.items():
+            self.mqttc.unsubscribe(topic)
+            self.mqttc.message_callback_remove(topic)
+        for _, topic in self.pose_topics.items():
             self.mqttc.unsubscribe(topic)
             self.mqttc.message_callback_remove(topic)
         if self.content_topic_point:
@@ -166,7 +177,7 @@ class RpcStreamingBadminton:
 
         self._setupUnsubscribe()
 
-    def start(self, content_mode="CES", tracknet_ver="tracknet_v2", record_mode="h264_high", tracknet_weight=None):
+    def start(self, content_mode="CES", tracknet_ver="tracknet_v2", record_mode="h264_high", tracknet_weight=None, pose_ver="OFF", pose_weight=None):
         """Start
 
         Args:
@@ -174,6 +185,8 @@ class RpcStreamingBadminton:
             tracknet_ver (str, optional): Tracknet 版本. Available options: ["tracknet_v2", "tracknet_1000"].
             record_mode (str, optional): Camera 錄影模式. Available options: ["none", "h264_low", "h264_high"].
             tracknet_weight (str | None, optional): Tracknet 權重檔名。若未提供則使用預設值。
+            pose_ver (str, optional): Pose 版本，"OFF" 表示關閉 Pose.
+            pose_weight (str | None, optional): Pose 權重檔名。若未提供則使用預設值。
         """
 
         self._verifyRequirements()
@@ -201,6 +214,9 @@ class RpcStreamingBadminton:
 
         camera_image_res = (512, 288)
         weight_name = (tracknet_weight or "").strip()
+        pose_ver_name = (pose_ver or "").strip()
+        pose_enabled = pose_ver_name.upper() != "OFF"
+        pose_weight_name = (pose_weight or "").strip()
 
         if tracknet_ver == "tracknet_1000":
             camera_image_res = (640, 480)
@@ -209,9 +225,7 @@ class RpcStreamingBadminton:
             for cam_idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
                 cameraAgent = self.manager.cameraLayerAgents[cam_idx]
                 ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_1000", weight_in_use, replay_dirname, cam_idx)
-                pose_ret = sensingAgent.startPose(cameraAgent.resolution, "best_int8_cu12.engine", replay_dirname=replay_dirname, cam_idx=cam_idx)
                 logging.info(f"TrackNet_{cam_idx}: {str(ret)}")
-                logging.info(f"Pose_{cam_idx}: {str(pose_ret)}")
         else:
             # tracknet_v2
             camera_image_res = (512, 288)
@@ -220,6 +234,13 @@ class RpcStreamingBadminton:
                 cameraAgent = self.manager.cameraLayerAgents[cam_idx]
                 ret = sensingAgent.startTrackNet(cameraAgent.resolution, "tracknet_v2", weight_in_use, replay_dirname, cam_idx)
                 logging.info(f"TrackNet_{cam_idx}: {str(ret)}")
+
+        if pose_enabled:
+            pose_weight_in_use = pose_weight_name or "best_int8_cu12.engine"
+            for cam_idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
+                cameraAgent = self.manager.cameraLayerAgents[cam_idx]
+                pose_ret = sensingAgent.startPose(cameraAgent.resolution, pose_weight_in_use, replay_dirname=replay_dirname, cam_idx=cam_idx)
+                logging.info(f"Pose_{cam_idx}: {str(pose_ret)}")
 
         # ====== Setup camera ======
 
@@ -254,6 +275,8 @@ class RpcStreamingBadminton:
         for idx, sensingAgent in list(self.manager.sensingLayerAgents.items()):
             ret = sensingAgent.stopTrackNet()
             logging.info(f"TrackNet_{idx}: {str(ret)}")
+            pose_ret = sensingAgent.stopPose(wait_for_eos=False)
+            logging.info(f"Pose_{idx}: {str(pose_ret)}")
 
         # ====== Stop content ======
         ret = self.manager.contentLayerAgent.stopModel3D()

--- a/LayerApplication/UI/Debug/StreamingDemoPage.py
+++ b/LayerApplication/UI/Debug/StreamingDemoPage.py
@@ -28,6 +28,10 @@ class StreamingDemoPage(QGroupBox):
     signal_tracknet_1 = pyqtSignal(bytes)
     signal_tracknet_2 = pyqtSignal(bytes)
     signal_tracknet_3 = pyqtSignal(bytes)
+    signal_pose_0 = pyqtSignal(bytes)
+    signal_pose_1 = pyqtSignal(bytes)
+    signal_pose_2 = pyqtSignal(bytes)
+    signal_pose_3 = pyqtSignal(bytes)
     signal_content_point = pyqtSignal(bytes)
     signal_content_event = pyqtSignal(bytes)
     signal_content_segment = pyqtSignal(bytes)
@@ -45,6 +49,10 @@ class StreamingDemoPage(QGroupBox):
         self.signal_tracknet_1.connect(self.sensing_callback_1)
         self.signal_tracknet_2.connect(self.sensing_callback_2)
         self.signal_tracknet_3.connect(self.sensing_callback_3)
+        self.signal_pose_0.connect(self.pose_callback_0)
+        self.signal_pose_1.connect(self.pose_callback_1)
+        self.signal_pose_2.connect(self.pose_callback_2)
+        self.signal_pose_3.connect(self.pose_callback_3)
         self.signal_content_point.connect(self.content_callback_point)
         self.signal_content_event.connect(self.content_callback_event)
         self.signal_content_segment.connect(self.content_callback_segment)
@@ -57,6 +65,10 @@ class StreamingDemoPage(QGroupBox):
         self.rpcStreamingBadminton.sensing_callbacks[1] = None
         self.rpcStreamingBadminton.sensing_callbacks[2] = None
         self.rpcStreamingBadminton.sensing_callbacks[3] = None
+        self.rpcStreamingBadminton.pose_callbacks[0] = None
+        self.rpcStreamingBadminton.pose_callbacks[1] = None
+        self.rpcStreamingBadminton.pose_callbacks[2] = None
+        self.rpcStreamingBadminton.pose_callbacks[3] = None
         self.rpcStreamingBadminton.content_callback_point = None
         self.rpcStreamingBadminton.content_callback_event = None
         self.rpcStreamingBadminton.content_callback_segment = None
@@ -73,6 +85,10 @@ class StreamingDemoPage(QGroupBox):
         self.rpcStreamingBadminton.sensing_callbacks[1] = lambda x: self.signal_tracknet_1.emit(x)
         self.rpcStreamingBadminton.sensing_callbacks[2] = lambda x: self.signal_tracknet_2.emit(x)
         self.rpcStreamingBadminton.sensing_callbacks[3] = lambda x: self.signal_tracknet_3.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[0] = lambda x: self.signal_pose_0.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[1] = lambda x: self.signal_pose_1.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[2] = lambda x: self.signal_pose_2.emit(x)
+        self.rpcStreamingBadminton.pose_callbacks[3] = lambda x: self.signal_pose_3.emit(x)
         self.rpcStreamingBadminton.content_callback_point = lambda x: self.signal_content_point.emit(x)
         self.rpcStreamingBadminton.content_callback_event = lambda x: self.signal_content_event.emit(x)
         self.rpcStreamingBadminton.content_callback_segment = lambda x: self.signal_content_segment.emit(x)
@@ -135,6 +151,28 @@ class StreamingDemoPage(QGroupBox):
         self.combo_tracknet_weight.addItems(weights)
         self.combo_tracknet_weight.setEnabled(bool(weights))
 
+    def _load_pose_weights(self):
+        version = self.combo_pose_ver.currentText()
+        self.combo_pose_weight.clear()
+
+        if version == "OFF":
+            self.combo_pose_weight.setEnabled(False)
+            return
+
+        base_dir = Path(ROOTDIR) / "LayerSensing" / "Pose" / "weights"
+        allowed_suffixes = {".engine", ".pt", ".pth", ".onnx"}
+        default_weight = "best_int8_cu12.engine"
+        weights = []
+
+        if base_dir.exists():
+            weights = [p.name for p in sorted(base_dir.iterdir()) if p.is_file() and p.suffix.lower() in allowed_suffixes]
+
+        if not weights:
+            weights.append(default_weight)
+
+        self.combo_pose_weight.addItems(weights)
+        self.combo_pose_weight.setEnabled(True)
+
     def startTest(self):
         self._clearOutput()
         self.ball_point_widget.reset()
@@ -163,10 +201,21 @@ class StreamingDemoPage(QGroupBox):
             record_mode = self.combo_record_mode.currentText()
             tracknet_ver = self.combo_tracknet_ver.currentText()
             tracknet_weight = self.combo_tracknet_weight.currentText().strip() if self.combo_tracknet_weight.count() else ""
+            pose_ver = self.combo_pose_ver.currentText()
+            pose_weight = self.combo_pose_weight.currentText().strip() if self.combo_pose_weight.isEnabled() and self.combo_pose_weight.count() else ""
 
-            self.rpcStreamingBadminton.start(content_mode=content_mode, tracknet_ver=tracknet_ver, record_mode=record_mode, tracknet_weight=tracknet_weight)
+            self.rpcCameraWidget.enablePoseOverlay(pose_ver != "OFF")
+            self.rpcStreamingBadminton.start(
+                content_mode=content_mode,
+                tracknet_ver=tracknet_ver,
+                record_mode=record_mode,
+                tracknet_weight=tracknet_weight,
+                pose_ver=pose_ver,
+                pose_weight=pose_weight,
+            )
             self.btn_run.setText(f"Stop")
         else:
+            self.rpcCameraWidget.enablePoseOverlay(False)
             self.rpcStreamingBadminton.stop()
             self.btn_run.setText("Run")
             self.trajectory_widget.render()
@@ -213,6 +262,27 @@ class StreamingDemoPage(QGroupBox):
         points = [ (int(p['pos']['x']), int(p['pos']['y'])) for p in jdata['linear'] ]
 
         self.rpcCameraWidget.updateTrackNetPoint(3, points)
+
+    def _pose_callback(self, cam_idx:int, data:bytes):
+        try:
+            jdata = json.loads(data)
+            detections = jdata.get("detection", [])
+            if isinstance(detections, list):
+                self.rpcCameraWidget.updatePoseData(cam_idx, detections)
+        except Exception as e:
+            logging.error(f"處理 Pose 資料時發生錯誤(cam={cam_idx}): {e}")
+
+    def pose_callback_0(self, data:bytes):
+        self._pose_callback(0, data)
+
+    def pose_callback_1(self, data:bytes):
+        self._pose_callback(1, data)
+
+    def pose_callback_2(self, data:bytes):
+        self._pose_callback(2, data)
+
+    def pose_callback_3(self, data:bytes):
+        self._pose_callback(3, data)
 
     def content_callback_point(self, data:str):
         """處理球點資料"""
@@ -391,6 +461,21 @@ class StreamingDemoPage(QGroupBox):
         tracknet_weight_layout.addWidget(label_tracknet_weight, stretch=1)
         tracknet_weight_layout.addWidget(self.combo_tracknet_weight, stretch=2)
 
+        pose_ver_layout = QHBoxLayout()
+        label_pose_ver = QLabel("Pose Ver.:")
+        self.combo_pose_ver = QComboBox()
+        self.combo_pose_ver.addItems(["OFF", "pose_trt"])
+        self.combo_pose_ver.setCurrentText("OFF")
+        self.combo_pose_ver.currentTextChanged.connect(self._load_pose_weights)
+        pose_ver_layout.addWidget(label_pose_ver, stretch=1)
+        pose_ver_layout.addWidget(self.combo_pose_ver, stretch=2)
+
+        pose_weight_layout = QHBoxLayout()
+        label_pose_weight = QLabel("Pose Weight:")
+        self.combo_pose_weight = QComboBox()
+        pose_weight_layout.addWidget(label_pose_weight, stretch=1)
+        pose_weight_layout.addWidget(self.combo_pose_weight, stretch=2)
+
         self.btn_run = QPushButton()
         self.btn_run.setText('Run')
         self.btn_run.setFixedSize(QSize(160, 60))
@@ -408,11 +493,14 @@ class StreamingDemoPage(QGroupBox):
         container_layout.addLayout(mode_layout)
         container_layout.addLayout(tracknet_ver_layout)
         container_layout.addLayout(tracknet_weight_layout)
+        container_layout.addLayout(pose_ver_layout)
+        container_layout.addLayout(pose_weight_layout)
         container_layout.addLayout(record_mode_layout)
         container_layout.addWidget(self.btn_run)
         container_layout.addWidget(self.btn_debug_run)
         container.setLayout(container_layout)
 
         self._load_tracknet_weights()
+        self._load_pose_weights()
 
         return container

--- a/LayerCamera/RpcCameraWidget.py
+++ b/LayerCamera/RpcCameraWidget.py
@@ -180,6 +180,8 @@ class RpcCameraWidget(QWidget):
             self.camera_label_list[i].setFixedSize(self.image_size_h)
 
         self.visualize_tracknet = [[] for _ in range(num)]
+        self.visualize_pose = [[] for _ in range(num)]
+        self.pose_overlay_enabled = False
 
         asyncio.run(self._startCamera(num))
 
@@ -200,6 +202,35 @@ class RpcCameraWidget(QWidget):
             for x, y in self.visualize_tracknet[cam_idx]:
                 context.arc(x, y, 5, 0, 2 * 3.14159)  # Circle with radius 5
             context.fill()
+
+        if self.pose_overlay_enabled and cam_idx < len(self.visualize_pose):
+            poses = self.visualize_pose[cam_idx]
+            for person in poses:
+                points = person.get("points", [])
+                if not points:
+                    continue
+
+                # yellow lines
+                context.set_source_rgb(1.0, 1.0, 0.0)
+                context.set_line_width(2.0)
+                for p1, p2 in self._pose_edges():
+                    if p1 >= len(points) or p2 >= len(points):
+                        continue
+                    x1, y1 = points[p1]
+                    x2, y2 = points[p2]
+                    if not self._is_valid_pose_point((x1, y1)) or not self._is_valid_pose_point((x2, y2)):
+                        continue
+                    context.move_to(x1, y1)
+                    context.line_to(x2, y2)
+                    context.stroke()
+
+                # pink keypoints
+                context.set_source_rgb(1.0, 0.55, 0.75)
+                for x, y in points:
+                    if not self._is_valid_pose_point((x, y)):
+                        continue
+                    context.arc(x, y, 2, 0, 2 * 3.14159)
+                    context.fill()
 
     def __createDisplayPipeline(self, idx):
 
@@ -251,18 +282,64 @@ class RpcCameraWidget(QWidget):
 
         PREVIEW_WIDTH, PREVIEW_HEIGHT = 320, 240
 
-        # rescale
-        coords = [(int(x/width*PREVIEW_WIDTH), int(y/height*PREVIEW_HEIGHT)) for x, y in coords]
-
-        # rotation
-        if self.cameraList[cam_idx].direction == 1:
-            coords = [(PREVIEW_WIDTH-y, x) for x, y in coords]
-        elif self.cameraList[cam_idx].direction == 2:
-            coords = [(PREVIEW_WIDTH-x, PREVIEW_HEIGHT-y) for x, y in coords]
-        elif self.cameraList[cam_idx].direction == 3:
-            coords = [(y, PREVIEW_HEIGHT-x) for x, y in coords]
+        coords = self._transform_preview_coords(cam_idx, coords, width, height, PREVIEW_WIDTH, PREVIEW_HEIGHT)
 
         self.visualize_tracknet[cam_idx] = coords
+
+    def _is_valid_pose_point(self, pt):
+        x, y = pt
+        return x > 0 and y > 0
+
+    def _pose_edges(self):
+        return [
+            (0, 1), (0, 2), (1, 3), (2, 4),
+            (5, 6), (5, 7), (7, 9), (6, 8), (8, 10),
+            (5, 11), (6, 12), (11, 12),
+            (11, 13), (13, 15), (12, 14), (14, 16),
+        ]
+
+    def _transform_preview_coords(self, cam_idx:int, coords:'list[(int, int)]', width:int, height:int, preview_width:int, preview_height:int):
+        if width <= 0 or height <= 0:
+            return []
+
+        scaled = [(int(x / width * preview_width), int(y / height * preview_height)) for x, y in coords]
+
+        direction = self.cameraList[cam_idx].direction
+        if direction == 1:
+            return [(preview_width - y, x) for x, y in scaled]
+        if direction == 2:
+            return [(preview_width - x, preview_height - y) for x, y in scaled]
+        if direction == 3:
+            return [(y, preview_height - x) for x, y in scaled]
+
+        return scaled
+
+    def updatePoseData(self, cam_idx:int, detections:list):
+        if cam_idx >= len(self.cameraList) or self.cameraList[cam_idx] is None:
+            return
+
+        width, height = self.cameraList[cam_idx].resolution
+        preview_width, preview_height = 320, 240
+
+        pose_people = []
+        for det in detections[:2]:
+            kpts = det.get("kpts", []) if isinstance(det, dict) else []
+            if not isinstance(kpts, list) or len(kpts) < 34:
+                continue
+
+            raw_points = []
+            for i in range(0, 34, 2):
+                raw_points.append((float(kpts[i]) * width, float(kpts[i + 1]) * height))
+
+            transformed = self._transform_preview_coords(cam_idx, raw_points, width, height, preview_width, preview_height)
+            pose_people.append({"points": transformed})
+
+        self.visualize_pose[cam_idx] = pose_people
+
+    def enablePoseOverlay(self, enabled:bool):
+        self.pose_overlay_enabled = enabled
+        if not enabled:
+            self.visualize_pose = [[] for _ in range(self.num_cameras)]
 
     def __startDisplay(self):
         if self.is_preview_playing:


### PR DESCRIPTION
### Motivation
- Allow users to completely disable Pose processing via the UI so Pose can be turned OFF without affecting TrackNet.
- Provide live visual feedback of detected skeletons on the camera preview when Pose is enabled.
- Keep existing TrackNet behavior unchanged and add Pose handling in a minimally invasive way.

### Description
- UI: added `Pose Ver.` and `Pose Weight` controls to the streaming debug panel and disabled the weight selector when `Pose Ver.` is `OFF`, and wired Pose signals/callbacks in `LayerApplication/UI/Debug/StreamingDemoPage.py`.
- RPC: added pose topic registration, subscribe/unsubscribe lifecycle, and optional per-camera Pose start/stop controlled by `pose_ver`/`pose_weight` in `LayerApplication/Rpc/RpcStreamingBadminton.py`.
- Camera overlay: added pose buffers, enable flag, coordinate transform helpers, `updatePoseData()` and `enablePoseOverlay()` and implemented drawing of pink keypoints and yellow skeleton lines in `LayerCamera/RpcCameraWidget.py`.
- Integration: Pose MQTT messages from sensing agents are parsed in the debug page and forwarded to the camera widget only when Pose is enabled, leaving TrackNet flows intact.

### Testing
- Compiled updated modules with `python -m py_compile LayerApplication/UI/Debug/StreamingDemoPage.py LayerApplication/Rpc/RpcStreamingBadminton.py LayerCamera/RpcCameraWidget.py` and the compile completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d772fcfd3883238ca3c2cf28be5b7e)